### PR TITLE
Fix changed link for sphinx-doc.org and url sheme

### DIFF
--- a/Documentation/WritingReST/Introduction.rst
+++ b/Documentation/WritingReST/Introduction.rst
@@ -67,7 +67,7 @@ This is the case for some additional directives such as the `:ref:` directives
 used for cross-referencing or the `toctree`.
 
 
-Additional information: `Sphinx Markup Constructs <http://www.sphinx-doc.org/en/1.6/markup/>`__
+Additional information: `Sphinx Markup Constructs <https://www.sphinx-doc.org/en/1.6/markup/>`__
 
 
 Rendering

--- a/Documentation/WritingReST/Introduction.rst
+++ b/Documentation/WritingReST/Introduction.rst
@@ -67,7 +67,7 @@ This is the case for some additional directives such as the `:ref:` directives
 used for cross-referencing or the `toctree`.
 
 
-Additional information: `Sphinx Markup Constructs <http://www.sphinx-doc.org/en/stable/markup/index.html>`__
+Additional information: `Sphinx Markup Constructs <http://www.sphinx-doc.org/en/1.6/markup/>`__
 
 
 Rendering


### PR DESCRIPTION
the origin link has changed:
- www.sphinx-doc.org/en/stable/.. no longer exists and will be forwarded to 
- www.sphinx-doc.org/en/master/.. where page /markup is not found
I recommend to use the last stable version number, instead. I could not found a better way to avoid specific version number.
If newer versions are available, it is written so in header of the page. For example see: www.sphinx-doc.org/en/1.4.9/markup/