### PR TITLE
Fix changed url for sphinx-doc.org and url sheme

### DIFF
--- a/Documentation/WritingReST/Hyperlinks.rst
+++ b/Documentation/WritingReST/Hyperlinks.rst
@@ -168,7 +168,7 @@ manuals correctly.
 
 
 Additional information: See the `Sphinx documentation
-<http://www.sphinx-doc.org/en/stable/markup/inline.html#cross-referencing-arbitrary-locations>`__.
+<https://www.sphinx-doc.org/en/1.6/markup/inline.html#cross-referencing-arbitrary-locations>`__.
 
 
 In the same manual


### PR DESCRIPTION
the origin url has changed:
- www.sphinx-doc.org/en/stable/.. no longer exists and will be forwarded to 
- www.sphinx-doc.org/en/master/.. where page /markup is not found
I recommend to use the last stable version number, instead. I could not found a better way to avoid specific version number.
If newer versions are available, it is written so in header of the page. For example see: www.sphinx-doc.org/en/1.4.9/markup/

Use HTTPS instead of HTTP