### PR TITLE
Fix information for tip: how to start documentation for your extension

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -27,6 +27,8 @@ Writing Documentation
 
    -  Extension Authors: :ref:`tip-edit-me-on-github`
    -  Extension Authors: :ref:`tip-link-to-issues`
+   -  :ref:`tip-of-the-day-trigger-rebuild`
+   -  Extension Authors: :ref:`tip-extension-rendered-old-layout`
 
    :ref:`General Tips ... <Tip-of-the-day>` | :ref:`Tips for extension authors ... <tips-extension-authors>`
 

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -11,7 +11,6 @@ Writing Documentation
 :License:         `Creative Commons License <https://en.wikipedia.org/wiki/Creative_Commons_license>`__ (CC BY 4.0)
 
 
-
 **About this manual:**
 
    This manual is about writing TYPO3 documentation
@@ -28,10 +27,8 @@ Writing Documentation
 
    -  Extension Authors: :ref:`tip-edit-me-on-github`
    -  Extension Authors: :ref:`tip-link-to-issues`
-   -  :ref:`tip-of-the-day-2017-02-13`
-   -  :ref:`tip-of-the-day-2016-10-08`
 
-   :ref:`All Tips ... <Tip-of-the-day>` | :ref:`Tips for extension authors ... <tips-extension-authors>`
+   :ref:`General Tips ... <Tip-of-the-day>` | :ref:`Tips for extension authors ... <tips-extension-authors>`
 
 **What's new in this guide?**
 

--- a/Documentation/TipOfTheDay.rst
+++ b/Documentation/TipOfTheDay.rst
@@ -116,46 +116,6 @@ Solution
    sublevel of `My Documentation` in the menu.
 
 
-
-.. _tip-of-the-day-2016-12-29:
-.. rst-class:: panel panel-default
-
-How to start Documentation for Your TYPO3 Extension
-===================================================
-
-**Update:** Please see :ref:`how-to-start-documentation-for-ext`
-for an up-to-date description of starting extension documentation from scratch
-using the example extension manual (2019-01-06).
-
-
-2016-12-29 by Martin Bless
-
-
-**Quickstart:**
-
--  Get yourself one of the T3DocumentationStarter projects that look like
-   https://docs.typo3.org/typo3cms/drafts/github/T3DocumentationStarter/Public-Info-000/
-
--  Read the frontpage of the starter to learn how it works.
-
--  You may edit directly at Github. Just do a little update and save (=push),
-   and some very few minutes later you can reload the page and see what the
-   server has rendered for you. You don't have to install or render anything yourself.
-   The server will do that for you.
-
--  Or work with Github as you usually do.
-
--  To become the owner of a starter project send a mail with your **Github username**
-   to the docteam to documentation@typo3.org and ask for a T3DocumentationStarter project.
-
--  Later: Copy the :file:`./Documentation` folder of the starter project to your extension.
-   Write your documentation. Edit the metadata in :file:`./Documentation/Settings.cfg` and
-   you are done.
-
-Come to the sunny side of documentation - have fun!
-
-
-
 .. _tip-of-the-day-2016-10-08:
 .. rst-class:: panel panel-default
 
@@ -255,7 +215,7 @@ having a border because they are not separated enough from the background. Examp
    a caption::
 
       .. figure:: images/2016-09-11-2.png
-        
+
 
 2. And this is what we see. The image is not clearly distinguished:
 

--- a/Documentation/WritingDocForExtension/CreateFromScratch.rst
+++ b/Documentation/WritingDocForExtension/CreateFromScratch.rst
@@ -16,8 +16,7 @@ your computer to check if the documentation is rendered correctly.
 
 This is the preferred workflow, but if you have problems with
 Docker or would like to edit directly on GitHub, see the older
-Tip of the Day `How to start Documentation for your TYPO3 Extension
-<https://docs.typo3.org/Tips/TipOfTheDay/Index.html#how-to-start-documentation-for-your-typo3-extensiontip-of-the-day-2016-12-29>`__.
+Tip of the Day :ref:`tip-of-the-day-2016-12-29`.
 
 If necessary, ask for help as explained in :ref:`how-to-get-help`.
 

--- a/Documentation/WritingDocForExtension/ExtensionAuthorTips.rst
+++ b/Documentation/WritingDocForExtension/ExtensionAuthorTips.rst
@@ -79,3 +79,40 @@ A link to the Issues will then be available in the "Related Links" section.
 
 Example extension: `news <https://docs.typo3.org/typo3cms/extensions/news/>`__
 
+
+.. _tip-of-the-day-2016-12-29:
+.. rst-class:: panel panel-default
+
+How to start Documentation for Your TYPO3 Extension (With Starter Project)
+==========================================================================
+
+**Update:** Please see :ref:`how-to-start-documentation-for-ext`
+for an up-to-date description of starting extension documentation from scratch
+using the example extension manual and rendering with Docker (2019-01-06).
+
+
+2016-12-29 by Martin Bless
+
+
+**Quickstart:**
+
+-  Get yourself one of the T3DocumentationStarter projects that look like
+   https://docs.typo3.org/typo3cms/drafts/github/T3DocumentationStarter/Public-Info-000/
+
+-  Read the frontpage of the starter to learn how it works.
+
+-  You may edit directly at Github. Just do a little update and save (=push),
+   and some very few minutes later you can reload the page and see what the
+   server has rendered for you. You don't have to install or render anything yourself.
+   The server will do that for you.
+
+-  Or work with Github as you usually do.
+
+-  To become the owner of a starter project send a mail with your **Github username**
+   to the docteam to documentation@typo3.org and ask for a T3DocumentationStarter project.
+
+-  Later: Copy the :file:`./Documentation` folder of the starter project to your extension.
+   Write your documentation. Edit the metadata in :file:`./Documentation/Settings.cfg` and
+   you are done.
+
+Come to the sunny side of documentation - have fun!

--- a/Documentation/WritingDocForExtension/ExtensionAuthorTips.rst
+++ b/Documentation/WritingDocForExtension/ExtensionAuthorTips.rst
@@ -80,6 +80,39 @@ A link to the Issues will then be available in the "Related Links" section.
 Example extension: `news <https://docs.typo3.org/typo3cms/extensions/news/>`__
 
 
+
+.. _tip-extension-rendered-old-layout:
+.. rst-class:: panel panel-default
+
+HELP: My extension documentation was rendered with the OLD layout!
+==================================================================
+
+2018-02-13 by Martin Bless
+
+That is actually a good sign. Why? Read on!
+
+Shortly after an extension upload to the TER the documentation server will
+render the documentation that (hopefully!) comes with that version.
+BUT: At the moment this automatic rendering process still uses the old layout.
+Unfortunately the current server is very old and can't run the new toolchain.
+And we haven't managed to switch everything to a new server yet. That is why
+you initially may feel you've done something wrong because that outdated
+layout is used.
+
+At the moment I'm running the new toolchain manually "every now and then" from my
+local machine. In general that should happen at least once a day. The plan is,
+of course, to set up a fully automated process for that. But we can't foresee
+at the moment when exactly that will be.
+
+What does this mean? If you see your documentation in the old layout that
+actually is a good sign. It proves that the documentation can be found and
+rendered. Just stay calm and patient until the new layout appears. That's the
+only thing you need to do.
+
+Easy - you can do it!
+
+
+
 .. _tip-of-the-day-2016-12-29:
 .. rst-class:: panel panel-default
 


### PR DESCRIPTION
- the tip has moved from homepage to this guide: fix link
- add information that it's about a starter project to title
- move tip from general tips to tips for extension authors