### PR TITLE
Restructure contribution workflows

### DIFF
--- a/Documentation/WritingDocsOfficial/GithubMethod.rst
+++ b/Documentation/WritingDocsOfficial/GithubMethod.rst
@@ -1,7 +1,121 @@
-:orphan:
-
 .. include:: ../Includes.txt
 .. highlight:: rst
 
-This page was moved to :ref:`docs-contribute-github-method`.
+.. _docs-contribute-github-method:
 
+================================
+Workflow #1: "Edit me on Github"
+================================
+
+.. youtube:: wNxO-aXY5Yw
+
+
+.. rst-class:: bignums-xxl
+
+1. Get a GitHub account:
+
+   `Join GitHub <https://github.com/join>`__
+
+2. Find a page that needs fixing:
+
+   Pick a manual, for example :ref:`t3start:start` or :ref:`t3install:start`
+   and find a page there, that you want to change.
+
+3. Click on "Edit me on GitHub":
+
+   You should find the button on the top right of any page!
+
+   .. image:: ../images/edit_me_on_github.png
+      :class: with-shadow
+
+4. Fork the repository:
+
+   Click on the green button to fork the repository.
+
+   .. image:: ../images/github-edit-fork.png
+      :class: with-shadow
+
+5. Make your changes:
+
+   You should now see an edit window where you can make your changes
+   directly. The settings *"Indent mode: Spaces"* and *"Indent size: 3"*
+   should already be correct, by default. Don't change that.
+
+   .. image:: ../images/github-edit-window.png
+      :class: with-shadow
+
+6. Handling reST:
+
+   The files are written in reST format. You can :ref:`learn more about reST
+   <rest-quick-start>` when you need it. For fixing simple typos and editing
+   unformatted text, you should be ok without knowledge about reST.
+
+7. Check Preview:
+
+   Click on "Preview changes" to see what you changed and how the final result
+   might look like.
+
+   Go back to the edit window and make more changes any time.
+
+   .. image:: ../images/github-edit-preview.png
+      :class: with-shadow
+
+8. Finalize your changes:
+
+   When you are ready, scroll down to the bottom of the page. Add
+   a short (!) text describing your changes and click on "Propose
+   file change"
+
+   .. image:: ../images/github-propose-file-changes.png
+      :class: with-shadow
+
+9. Create pull request:
+
+   GitHub will now show you an overview of your changes. If this is
+   ok, click on "Create pull request".
+
+   .. image:: ../images/github-comparing-changes.png
+      :class: with-shadow
+
+   And finally, create your pull request:
+
+   .. image:: ../images/github-create-pull-request2.png
+      :class: with-shadow
+
+10. You're done!
+
+   Well, almost. Your change will now be reviewed. A reviewer might
+   suggest changes. Monitor your notifications (email) from GitHub. If at any
+   point, you are not sure what to do, don't hesitate to
+   :ref:`ask for help <how-to-get-help>`. When your pull request is accepted,
+   it will be merged. You will get a notification (email).
+
+
+**Congratulations! You are now a contributor. Welcome and thank you!**
+
+Wait a few minutes for the changes to be automatically rendered, and then
+reload the page (which you fixed) in your browser.
+
+Next month, you can find your name on the "Developer Appreciation Day"
+(DAD) page on the `TYPO3 Blog <https://typo3.com/blog/tag/contribution/>`__.
+
+See `June 2018: Developer Appreciation Day
+<https://typo3.com/blog/june-2018-developer-appreciation-day-dad/?utm_medium=TYPO3%2BBlog&utm_source=Blog%2BPost%2B-%2BJune%2B2018%3A%2BDeveloper%2BAppreciation%2BDay%2B%28DAD%29>`__
+for an example.
+
+
+.. image:: ../images/dad-with-image.png
+   :target: https://typo3.com/blog/june-2018-developer-appreciation-day-dad/?utm_medium=TYPO3%2BBlog&utm_source=Blog%2BPost%2B-%2BJune%2B2018%3A%2BDeveloper%2BAppreciation%2BDay%2B%28DAD%29
+   :class: with-shadow
+
+Scroll down to "Improving documentation":
+
+.. image:: ../images/dad-improve-docs.png
+   :target: https://typo3.com/blog/june-2018-developer-appreciation-day-dad/?utm_medium=TYPO3%2BBlog&utm_source=Blog%2BPost%2B-%2BJune%2B2018%3A%2BDeveloper%2BAppreciation%2BDay%2B%28DAD%29
+   :class: with-shadow
+
+
+Next Steps
+==========
+
+* Look at :ref:`docs-official-how-you-can-help` for more ways to contribute

--- a/Documentation/WritingDocsOfficial/Index.rst
+++ b/Documentation/WritingDocsOfficial/Index.rst
@@ -1,9 +1,9 @@
 .. include:: ../Includes.txt
 .. highlight:: rst
 
-
+.. _contribute:
 .. _docs-contribute:
-.. _docs-contribute-github-method:
+.. _docs-official-workflow-methods:
 
 ===========================================
 How to Contribute to Official Documentation
@@ -18,128 +18,51 @@ you go along.
 Your changes will not be visible right away, someone
 must merge them. So, don't worry about breaking something!
 
-.. tip::
-
-   If you are familiar with Git and Docker, you may want to skip
-   straight to :ref:`docs-contribute-git-docker`, which describes
-   the local workflow.
-
-.. youtube:: wNxO-aXY5Yw
-
-
 If you're stuck at any point, don't hesitate
 to :ref:`ask for help <how-to-get-help>`.
 
-.. rst-class:: bignums-xxl
+There are 2 different workflows which you can use to make changes.
+Use what you are most comfortable with!
 
-1. Get a GitHub account:
+.. tip::
 
-   `Join GitHub <https://github.com/join>`__
+   We recommend to try out the :ref:`"Edit me on Github" workflow <docs-contribute-github-method>`,
+   because it is a way to quickly make changes, but use :ref:`"Local Editing and Rendering
+   with Docker" <docs-contribute-git-docker>` in the long run for larger
+   changes.
 
-2. Find a page that needs fixing:
+.. rst-class:: bignums
 
-   Pick a manual, for example :ref:`t3start:start` or :ref:`t3install:start`
-   and find a page there, that you want to change.
+   1. "Edit me on Github" workflow
 
-3. Click on "Edit me on GitHub":
+      You can edit documentation directly online in your browser.
 
-   You should find the button on the top right of any page!
+      This workflow can be used for minor changes.
 
-   .. image:: ../images/edit_me_on_github.png
-      :class: with-shadow
+      For extensive changes, it is recommended to use "Local Editing
+      and Rendering with Docker".
 
-4. Fork the repository:
+      **Get started:** :ref:`docs-contribute-github-method`.
 
-   Click on the green button to fork the repository.
+   2. "Local Editing and Rendering with Docker" workflow
 
-   .. image:: ../images/github-edit-fork.png
-      :class: with-shadow
+      If you are familiar with Git, Docker and the command line,
+      you can use this workflow. In fact, it is recommended.
 
-5. Make your changes:
+      If you already contributed to other projects on GitHub via
+      pull requests, you should already be familiar with this workflow.
+      The only difference to a general GitHub contribution workflow
+      using Git is the local rendering with Docker!
 
-   You should now see an edit window where you can make your changes
-   directly. The settings *"Indent mode: Spaces"* and *"Indent size: 3"*
-   should already be correct, by default. Don't change that.
-
-   .. image:: ../images/github-edit-window.png
-      :class: with-shadow
-
-6. Handling reST:
-
-   The files are written in reST format. You can :ref:`learn more about reST
-   <rest-quick-start>` when you need it. For fixing simple typos and editing
-   unformatted text, you should be ok without knowledge about reST.
-
-7. Check Preview:
-
-   Click on "Preview changes" to see what you changed and how the final result
-   might look like.
-
-   Go back to the edit window and make more changes any time.
-
-   .. image:: ../images/github-edit-preview.png
-      :class: with-shadow
-
-8. Finalize your changes:
-
-   When you are ready, scroll down to the bottom of the page. Add
-   a short (!) text describing your changes and click on "Propose
-   file change"
-
-   .. image:: ../images/github-propose-file-changes.png
-      :class: with-shadow
-
-9. Create pull request:
-
-   GitHub will now show you an overview of your changes. If this is
-   ok, click on "Create pull request".
-
-   .. image:: ../images/github-comparing-changes.png
-      :class: with-shadow
-
-   And finally, create your pull request:
-
-   .. image:: ../images/github-create-pull-request2.png
-      :class: with-shadow
-
-10. You're done!
-
-   Well, almost. Your change will now be reviewed. A reviewer might
-   suggest changes. Monitor your notifications (email) from GitHub. If at any
-   point, you are not sure what to do, don't hesitate to
-   :ref:`ask for help <how-to-get-help>`. When your pull request is accepted,
-   it will be merged. You will get a notification (email).
+      **Get started:** :ref:`docs-contribute-git-docker`
 
 
-**Congratulations! You are now a contributor. Welcome and thank you!**
-
-Wait a few minutes for the changes to be automatically rendered, and then
-reload the page (which you fixed) in your browser.
-
-Next month, you can find your name on the "Developer Appreciation Day"
-(DAD) page on the `TYPO3 Blog <https://typo3.com/blog/tag/contribution/>`__.
-
-See `June 2018: Developer Appreciation Day
-<https://typo3.com/blog/june-2018-developer-appreciation-day-dad/?utm_medium=TYPO3%2BBlog&utm_source=Blog%2BPost%2B-%2BJune%2B2018%3A%2BDeveloper%2BAppreciation%2BDay%2B%28DAD%29>`__
-for an example.
-
-
-.. image:: ../images/dad-with-image.png
-   :target: https://typo3.com/blog/june-2018-developer-appreciation-day-dad/?utm_medium=TYPO3%2BBlog&utm_source=Blog%2BPost%2B-%2BJune%2B2018%3A%2BDeveloper%2BAppreciation%2BDay%2B%28DAD%29
-   :class: with-shadow
-
-Scroll down to "Improving documentation":
-
-.. image:: ../images/dad-improve-docs.png
-   :target: https://typo3.com/blog/june-2018-developer-appreciation-day-dad/?utm_medium=TYPO3%2BBlog&utm_source=Blog%2BPost%2B-%2BJune%2B2018%3A%2BDeveloper%2BAppreciation%2BDay%2B%28DAD%29
-   :class: with-shadow
 
 
 
 .. toctree::
    :hidden:
 
-   HowYouCanHelp
-   WorkflowMethods
+   GithubMethod
    LocalEditing
-
+   HowYouCanHelp

--- a/Documentation/WritingDocsOfficial/LocalEditing.rst
+++ b/Documentation/WritingDocsOfficial/LocalEditing.rst
@@ -3,9 +3,9 @@
 
 .. _docs-contribute-git-docker:
 
-=======================================
-Local Editing and Rendering with Docker
-=======================================
+======================================================
+Workflow #2: "Local Editing and Rendering with Docker"
+======================================================
 
 This section walks you through contributing to the documentation
 with Git and Docker.

--- a/Documentation/WritingDocsOfficial/WorkflowMethods.rst
+++ b/Documentation/WritingDocsOfficial/WorkflowMethods.rst
@@ -1,41 +1,12 @@
+:orphan:
+
 .. include:: ../Includes.txt
 .. highlight:: rst
 
-
-.. _docs-official-workflow-methods:
 
 ============================
 Overview of Workflow methods
 ============================
 
-There are different workflow methods which you can use to make changes.
-Use what you are most comfortable with!
-
-
-.. rst-class:: bignums
-
-   1. "Edit me on Github" workflow (which was used in the introduction
-      of this chapter)
-
-      You can edit documentation directly online in your browser.
-
-      This workflow can be used for minor changes.
-
-      For extensive changes, it is recommended to use "Local Editing
-      and Rendering with Docker".
-
-      **Get started:** :ref:`"Edit me on Github"
-      <docs-contribute-github-method>`.
-
-   2. "Local Editing and Rendering with Docker"
-
-      If you are familiar with Git, Docker and the command line,
-      you can use this workflow.
-
-      **Get started:** :ref:`docs-contribute-git-docker`
-
-We recommend to try out the "Edit me on Github" workflow, because it is
-a way to quickly make changes, but use :ref:`"Local Editing and Rendering
-with Docker" <docs-contribute-git-docker>` in the long run for larger
-changes.
-
+See :ref:`docs-official-workflow-methods` for an overview of workflow
+methods.


### PR DESCRIPTION
In the past, we had the description of the "Edit me on GitHub" workflow on
the start page of the Contribution chapter. This might result in people
being pushed towards this workflow. And it may be confusing not to
make clear there are 2 different workflows straight up front.

This commit:

- describes the workflows first
- clearly labels and numbers subchapters