### PR TITLE
Add alternative method for documentation rendering

### DIFF
--- a/Documentation/RenderingDocs/Quickstart.rst
+++ b/Documentation/RenderingDocs/Quickstart.rst
@@ -33,6 +33,10 @@ Commands to Render Documentation
 
    docker pull t3docs/render-documentation
    source <(docker run --rm t3docs/render-documentation show-shell-commands)
+   # If the command above will fail, please run the following three commands:
+   # mkdir -p ~/bin
+   # docker run --rm t3docs/render-documentation show-shell-commands > ~/bin/t3docs
+   # source ~/bin/t3docs
    dockrun_t3rd makehtml
    xdg-open "Documentation-GENERATED-temp/Result/project/0.0.0/Index.html"
 

--- a/Documentation/RenderingDocs/Quickstart.rst
+++ b/Documentation/RenderingDocs/Quickstart.rst
@@ -29,16 +29,22 @@ Commands to Render Documentation
 ================================
 
 .. code-block:: bash
-   :linenos:
 
    docker pull t3docs/render-documentation
    source <(docker run --rm t3docs/render-documentation show-shell-commands)
-   # If the command above will fail, please run the following three commands:
-   # mkdir -p ~/bin
-   # docker run --rm t3docs/render-documentation show-shell-commands > ~/bin/t3docs
-   # source ~/bin/t3docs
    dockrun_t3rd makehtml
    xdg-open "Documentation-GENERATED-temp/Result/project/0.0.0/Index.html"
+
+.. note::
+
+   If above command does not work, use the following instead:
+
+   .. code-block:: bash
+
+      mkdir -p ~/bin
+      docker run --rm t3docs/render-documentation show-shell-commands > ~/bin/t3docs
+      source ~/bin/t3docs
+      xdg-open "Documentation-GENERATED-temp/Result/project/0.0.0/Index.html"
 
 Explanations, the numbers correspond to the line numbers in code snippet:
 


### PR DESCRIPTION
On some Macs, the source command will fail. Therefore an alternative method is provided.