### PR TITLE
Improve start page of conventions

### DIFF
--- a/Documentation/GeneralConventions/Index.rst
+++ b/Documentation/GeneralConventions/Index.rst
@@ -4,33 +4,61 @@
 .. _general-conventions:
 .. _conventions:
 
-================================
-Conventions, CGL, Best Practices
-================================
+=================================
+Documentation content style guide
+=================================
 
-In general, the documentation follows the conventions as described in the
-following sections.
+This contains conventions, coding guidelines and best practices for TYPO3
+documentation. In general, the documentation follows the conventions as
+described in the following sections.
 
-But ... please do not get overwhelmed by the vast amount of information and "rules".
-You can start writing documentation right away, before having read all this and
-learn as you go along! The sections in this chapter are meant to help you in
-this task and not make it excruciatingly difficult and tedious! When you
-make a change to the official documentation, there is always a maintainer who
-will check the changes. He or she may give you some friendly words of advice
-if something is not ok.
+Finding common conventions is an ongoing task. Some of the decisions are
+still pending. For a list of open topics, see the "Documentation" category
+on `decisions.typo3.org <https://decisions.typo3.org/c/documentation>`__
 
-.. figure:: ../images/DefiningStandards-xkcd-927.png
-   :class: with-shadow
-   :alt: Xkcd image about standards
-   :target: https://xkcd.com/927/
+The most important conventions are summarized on this page, the rest can
+be found in the subchapters.
 
-   The attempt to unify 14 standards will result in 15
-   (Source: xkcd https://xkcd.com/927/, Copyright: `CC BY-NC 2.5
-   <https://creativecommons.org/licenses/by-nc/2.5/>`__)
+.. rst-class:: bignums-xxl
 
+#. Title capitalization
+
+   Use :ref:`sentence case <spelling-title-case>` - this means the title and
+   headers will be capitalized like normal sentences. The first word
+   is always capitalized and the rest is spelled as they would in
+   "normal text".
+
+   This is different from "TYPO3 content style guide" which capitalizes
+   more words in the title. Capitalization in the documentation is still
+   inconsistent currently, so you cannot rely on existing pages to show
+   the correct convention.
+
+#. Spelling
+
+   Use common spelling for American English. Some specific TYPO3 terms
+   have a special spelling. See :ref:`spelling-ref`
+
+#. Coding guidelines for headers
+
+   Headline underline should follow :ref:`rest-cgl-headline-underlines`::
+
+      =====
+      Title
+      =====
+
+      First header level
+      ==================
+
+      Second header level
+      -------------------
+
+      Third header level
+      ~~~~~~~~~~~~~~~~~~
+
+**Table of contents**
 
 .. toctree::
-   :hidden:
+   :maxdepth: 1
 
    ContentStyleGuide
    DirectoryFilenames
@@ -39,5 +67,4 @@ if something is not ok.
    CodingGuidelines
    GuidelinesForImages
    CommitMessages
-   HowToUpdateDocs
    Licenses

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -63,13 +63,14 @@ Writing Documentation
    ToolsEditRest/Index
    RenderingDocs/Index
    GitHub/Index
-   HowToAddTranslation/Index
 
 
 .. toctree::
    :hidden:
    :caption: ADVANCED
 
+   HowToAddTranslation/Index
+   ../GeneralConventions/HowToUpdateDocs
    T3DocTeam @ Work  ➜  <https://docs.typo3.org/typo3cms/Teams/T3DocTeam/>
 
 .. toctree::


### PR DESCRIPTION
- rename to "Documentation content style guide"
- add the most important conventions to start page
- move "How to update for new releases" to "Advanced" section