### PR TITLE
Suggest Docker Compose version 3

### DIFF
--- a/Documentation/RenderingDocs/RenderWithDockerCompose.rst
+++ b/Documentation/RenderingDocs/RenderWithDockerCompose.rst
@@ -44,14 +44,14 @@ work fine on all platforms.
 
    .. code-block:: yaml
 
-      version: '2'
+      version: '3'
       services:
         t3docmake:
           image: t3docs/render-documentation:latest
-          volumes:
-          - ./:/PROJECT:ro
-          - ./Documentation-GENERATED-temp:/RESULT
           command: makehtml
+          volumes:
+            - ./:/PROJECT:ro
+            - ./Documentation-GENERATED-temp:/RESULT
 
 #. Run docker-compose
 


### PR DESCRIPTION
There is no reason to use version 2 anymore.