### PR TITLE
Remove docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,0 @@
-version: '2'
-services:
-  t3docmake:
-    image: t3docs/render-documentation:latest
-    volumes:
-    - ./:/PROJECT:ro
-    - ./Documentation-GENERATED-temp:/RESULT
-    command: makehtml


### PR DESCRIPTION
Reasons: A common docker-compose.yml can be used instead, should
not add files for specific commands (that may change in the future)
etc.

See comment in related PR.

Related: TYPO3-Documentation/TYPO3CMS-Reference-Typoscript#297