### PR TITLE
Use Includes.rst.txt and absolute pathnames

### DIFF
--- a/Documentation/About.rst
+++ b/Documentation/About.rst
@@ -1,4 +1,4 @@
-.. include:: Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 

--- a/Documentation/Appendix/ExampleTocTree/Index.rst
+++ b/Documentation/Appendix/ExampleTocTree/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _example-toctree:

--- a/Documentation/Appendix/ExampleTocTree/Topic1/Index.rst
+++ b/Documentation/Appendix/ExampleTocTree/Topic1/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _example-toctree-topic1:

--- a/Documentation/Appendix/ExampleTocTree/Topic1/Subtopic1.rst
+++ b/Documentation/Appendix/ExampleTocTree/Topic1/Subtopic1.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _example-toctree-subtopic1:

--- a/Documentation/Appendix/ExampleTocTree/Topic1/Subtopic2.rst
+++ b/Documentation/Appendix/ExampleTocTree/Topic1/Subtopic2.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _example-toctree-subtopic2:

--- a/Documentation/Appendix/Index.rst
+++ b/Documentation/Appendix/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 
 ========
 Appendix

--- a/Documentation/Appendix/ResourcesForEditors.rst
+++ b/Documentation/Appendix/ResourcesForEditors.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 
 ==================================
 Information for Editing This Guide

--- a/Documentation/BasicPrinciples.rst
+++ b/Documentation/BasicPrinciples.rst
@@ -1,4 +1,4 @@
-.. include:: Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _basic-principles:

--- a/Documentation/Changes.rst
+++ b/Documentation/Changes.rst
@@ -1,6 +1,6 @@
 :orphan:
 
-.. include:: Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _changes:
 

--- a/Documentation/GeneralConventions/CodingGuidelines.rst
+++ b/Documentation/GeneralConventions/CodingGuidelines.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _format-rest-cgl:

--- a/Documentation/GeneralConventions/CommitMessages.rst
+++ b/Documentation/GeneralConventions/CommitMessages.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _general-conventions-commit-messages:

--- a/Documentation/GeneralConventions/ContentStyleGuide.rst
+++ b/Documentation/GeneralConventions/ContentStyleGuide.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _content-styleguide:

--- a/Documentation/GeneralConventions/DirectoryFilenames.rst
+++ b/Documentation/GeneralConventions/DirectoryFilenames.rst
@@ -410,7 +410,6 @@ Example:
    <https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument/blob/master/Documentation/Includes.txt>`__
 
 .. literalinclude:: ../Includes.rst.txt
-.. literalinclude:: ../Includes.rst.txt
    :language: rst
 
 

--- a/Documentation/GeneralConventions/DirectoryFilenames.rst
+++ b/Documentation/GeneralConventions/DirectoryFilenames.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _general-conventions-dir-and-filenames:
@@ -185,7 +185,7 @@ Index.rst:
 .. code-block:: rst
    :linenos:
 
-   .. include:: Includes.txt
+   .. include:: /Includes.rst.txt
 
    =====
    Title
@@ -201,7 +201,7 @@ Index.rst:
       Configuration
 
 
-* line 1 : every .rst file should include Includes.txt
+* line 1 : every .rst file should include /Includes.rst.txt
 * line 3-5: the header
 * line 10-14: the toctree defines which other pages will be included
   and combined. The menu is generated from all combined files (recursively).
@@ -212,7 +212,7 @@ Introduction.rst:
 
 .. code-block:: rst
 
-   .. include:: ../Includes.txt
+   .. include:: /Includes.rst.txt
 
    ============
    Introduction
@@ -273,7 +273,7 @@ Content
    ... text with configuration ...
 
 
-* line 1 : every .rst file should include Includes.txt
+* line 1 : every .rst file should include /Includes.rst.txt
 * line 3-5: the title
 * Here, all text is contained in one file.
 
@@ -395,20 +395,21 @@ This is :file:`Settings.cfg` for this manual.
 
 .. _includes-txt:
 
-Includes.txt
-============
+Includes.rst.txt
+================
 
 *-- optional (recommended for official documentation)*
 
-:file:`Documentation/Includes.txt`
+:file:`Documentation/Includes.rst.txt`
 
 This file can be the same for all Documentation projects!
 
 Example:
 
-* `Includes.txt in this manual <https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument/blob/master/Documentation/Includes.txt>`__
+* `Includes.rst.txt in this manual <https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument/blob/master/Documentation/Includes.rst.txt>`__
 
-.. literalinclude:: ../Includes.txt
+.. literalinclude:: ../Includes.rst.txt
+.. literalinclude:: ../Includes.rst.txt
    :language: rst
 
 

--- a/Documentation/GeneralConventions/Format.rst
+++ b/Documentation/GeneralConventions/Format.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _supported-formats:

--- a/Documentation/GeneralConventions/Glossary.rst
+++ b/Documentation/GeneralConventions/Glossary.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 

--- a/Documentation/GeneralConventions/GuidelinesForImages.rst
+++ b/Documentation/GeneralConventions/GuidelinesForImages.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _guidelines-for-images:

--- a/Documentation/GeneralConventions/HowToUpdateDocs.rst
+++ b/Documentation/GeneralConventions/HowToUpdateDocs.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _howto-update-docs:

--- a/Documentation/GeneralConventions/Index.rst
+++ b/Documentation/GeneralConventions/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _general-conventions:

--- a/Documentation/GeneralConventions/Licenses.rst
+++ b/Documentation/GeneralConventions/Licenses.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _general-conventions-licenses:

--- a/Documentation/GeneralConventions/MenuHierarchy.rst
+++ b/Documentation/GeneralConventions/MenuHierarchy.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _general-conventions-menu-hierarchy:

--- a/Documentation/GeneralConventions/ReviewInformation.rst
+++ b/Documentation/GeneralConventions/ReviewInformation.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _guidelines-for-reviewing:

--- a/Documentation/GitHub/Index.rst
+++ b/Documentation/GitHub/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _work-with-github:

--- a/Documentation/HowToAddTranslation/Index.rst
+++ b/Documentation/HowToAddTranslation/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _add-translation:

--- a/Documentation/HowToGetHelp.rst
+++ b/Documentation/HowToGetHelp.rst
@@ -1,4 +1,4 @@
-.. include:: Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _how-to-get-help:
 .. _slack:

--- a/Documentation/Includes.rst.txt
+++ b/Documentation/Includes.rst.txt
@@ -1,9 +1,8 @@
-.. This is 'Includes.txt'. It is included at the very top of each and
+.. This is 'Includes.rst.txt'. It is included at the very top of each and
    every ReST source file in THIS documentation project (= manual).
    
 .. This files lives at 
-   https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument/blob/master/Documentation/Includes.txt
-   Version: 2018-10-16
+   https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument/blob/master/Documentation/Includes.rst.txt
 
 .. More information about this file:
    https://docs.typo3.org/typo3cms/HowToDocument/GeneralConventions/DirectoryFilenames.html#includes-txt

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,4 +1,4 @@
-.. include:: Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _start:
 

--- a/Documentation/Maintainers/BackportChanges.rst
+++ b/Documentation/Maintainers/BackportChanges.rst
@@ -1,4 +1,4 @@
-.. include:: /Includes.txt
+.. include:: /Includes.rst.txt
 
 .. highlight:: shell
 

--- a/Documentation/Maintainers/Index.rst
+++ b/Documentation/Maintainers/Index.rst
@@ -1,4 +1,4 @@
-.. include:: /Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _maintainers:
 

--- a/Documentation/RenderingDocs/Index.rst
+++ b/Documentation/RenderingDocs/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _rendering-docs:

--- a/Documentation/RenderingDocs/Quickstart.rst
+++ b/Documentation/RenderingDocs/Quickstart.rst
@@ -1,5 +1,5 @@
 
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: bash
 
 .. _render-documenation-with-docker:

--- a/Documentation/RenderingDocs/RenderWithDockerCompose.rst
+++ b/Documentation/RenderingDocs/RenderWithDockerCompose.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: bash
 
 .. _render-with-docker-compose:

--- a/Documentation/RenderingDocs/Troubleshooting.rst
+++ b/Documentation/RenderingDocs/Troubleshooting.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: bash
 
 .. _rendering-docs-troubleshooting:
@@ -117,14 +117,14 @@ Everything with exitcode != 0 is relevant. Here, we see a problem
 with the requirements. This is usually caused by an incorrect path
 for including a file.
 
-Remember, every file includes :file:`Includes.txt` at the top. Check your
+Remember, every file includes :file:`Includes.rst.txt` at the top. Check your
 latest changes.
 
 .. code-block:: none
 
-   .. include:: ../Includes.txt
+   .. include:: ../Includes.rst.txt
 
-Correct the path, so it will point to the existing Includes.txt (which
+Correct the path, so it will point to the existing Includes.rst.txt (which
 should be located in the directory :file:`Documentation`.
 
 .. _render-troubleshooting-warnings:

--- a/Documentation/RenderingDocs/Troubleshooting.rst
+++ b/Documentation/RenderingDocs/Troubleshooting.rst
@@ -122,7 +122,7 @@ latest changes.
 
 .. code-block:: none
 
-   .. include:: ../Includes.rst.txt
+   .. include:: /Includes.rst.txt
 
 Correct the path, so it will point to the existing Includes.rst.txt (which
 should be located in the directory :file:`Documentation`.

--- a/Documentation/Targets.rst
+++ b/Documentation/Targets.rst
@@ -1,6 +1,6 @@
 :orphan:
 
-.. include:: Includes.txt
+.. include:: /Includes.rst.txt
 
 .. only:: html
 

--- a/Documentation/TipOfTheDayOld.rst
+++ b/Documentation/TipOfTheDayOld.rst
@@ -1,6 +1,6 @@
 :orphan:
 
-.. include:: Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _Tip-of-the-day-outdated:
 

--- a/Documentation/ToolsEditRest/Index.rst
+++ b/Documentation/ToolsEditRest/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _tools:

--- a/Documentation/WhatsNew.rst
+++ b/Documentation/WhatsNew.rst
@@ -3,7 +3,7 @@
 .. editor's note: this page is not included in the menu in the toctree
 ..                it is linked from the start page
 
-.. include:: Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _whats-new:
 

--- a/Documentation/WritingContent/Guide.rst
+++ b/Documentation/WritingContent/Guide.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 

--- a/Documentation/WritingContent/Index.rst
+++ b/Documentation/WritingContent/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _writing-content:

--- a/Documentation/WritingContent/Resources.rst
+++ b/Documentation/WritingContent/Resources.rst
@@ -1,4 +1,4 @@
-.. include:: Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _resources:
 

--- a/Documentation/WritingContent/Tutorial.rst
+++ b/Documentation/WritingContent/Tutorial.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. todo:: Add information about writing a tutorial

--- a/Documentation/WritingContent/WritingContentTips.rst
+++ b/Documentation/WritingContent/WritingContentTips.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _write-good-content:

--- a/Documentation/WritingDocForExtension/ContributeToSystemExtension.rst
+++ b/Documentation/WritingDocForExtension/ContributeToSystemExtension.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _contribute-to-system-extension:

--- a/Documentation/WritingDocForExtension/ContributeToThirdPartyExtension.rst
+++ b/Documentation/WritingDocForExtension/ContributeToThirdPartyExtension.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _contribute-to-3rdparty-extension:

--- a/Documentation/WritingDocForExtension/CreateFromScratch.rst
+++ b/Documentation/WritingDocForExtension/CreateFromScratch.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _how-to-start-documentation-for-ext:

--- a/Documentation/WritingDocForExtension/CreateWithExtensionBuilder.rst
+++ b/Documentation/WritingDocForExtension/CreateWithExtensionBuilder.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _doc-for-ext-with-extension-builder:

--- a/Documentation/WritingDocForExtension/FAQ.rst
+++ b/Documentation/WritingDocForExtension/FAQ.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _faq-for-extension-authors:
 .. _tips-extension-authors:

--- a/Documentation/WritingDocForExtension/Index.rst
+++ b/Documentation/WritingDocForExtension/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _writing-doc-for-ext-start:

--- a/Documentation/WritingDocForExtension/Introduction.rst
+++ b/Documentation/WritingDocForExtension/Introduction.rst
@@ -1,6 +1,6 @@
 :orphan:
 
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 

--- a/Documentation/WritingDocForExtension/Migrate.rst
+++ b/Documentation/WritingDocForExtension/Migrate.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _migrate:
 .. _register-for-rendering:

--- a/Documentation/WritingDocForExtension/ReregisterVersions.rst
+++ b/Documentation/WritingDocForExtension/ReregisterVersions.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: bash
 
 .. _reregister-versions:

--- a/Documentation/WritingDocForExtension/Webhook.rst
+++ b/Documentation/WritingDocForExtension/Webhook.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _webhook:
 

--- a/Documentation/WritingDocsOfficial/GithubMethod.rst
+++ b/Documentation/WritingDocsOfficial/GithubMethod.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _docs-contribute-github-method:

--- a/Documentation/WritingDocsOfficial/HowYouCanHelp.rst
+++ b/Documentation/WritingDocsOfficial/HowYouCanHelp.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 

--- a/Documentation/WritingDocsOfficial/Index.rst
+++ b/Documentation/WritingDocsOfficial/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _contribute:

--- a/Documentation/WritingDocsOfficial/LocalEditing.rst
+++ b/Documentation/WritingDocsOfficial/LocalEditing.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _docs-contribute-git-docker:

--- a/Documentation/WritingDocsOfficial/Quickstart.rst
+++ b/Documentation/WritingDocsOfficial/Quickstart.rst
@@ -1,6 +1,6 @@
 :orphan:
 
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 
 =====
 Moved

--- a/Documentation/WritingDocsOfficial/WorkflowMethods.rst
+++ b/Documentation/WritingDocsOfficial/WorkflowMethods.rst
@@ -1,6 +1,6 @@
 :orphan:
 
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 

--- a/Documentation/WritingReST/Admonitions.rst
+++ b/Documentation/WritingReST/Admonitions.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _rest-admonitions:

--- a/Documentation/WritingReST/BasicRestSyntax.rst
+++ b/Documentation/WritingReST/BasicRestSyntax.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _basic-rest-syntax:

--- a/Documentation/WritingReST/BignumLists.rst
+++ b/Documentation/WritingReST/BignumLists.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _styled-numbered-lists:

--- a/Documentation/WritingReST/BoldItalic.rst
+++ b/Documentation/WritingReST/BoldItalic.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _rest-bold-italic:

--- a/Documentation/WritingReST/CheatSheet.rst
+++ b/Documentation/WritingReST/CheatSheet.rst
@@ -2,15 +2,15 @@
 
 .. -----------------------------------------------------------
    include directive: Here, it includes the file
-   Includes.txt. All files in the documentation project should
+   Includes.rst.txt. All files in the documentation project should
    do this. Use correct path!
    -----------------------------------------------------------
 
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. ------------------------------------------------------------------
    highlight directive: sets the default language for code-blocks.
-   Usually, default is set to PHP in Includes.txt. Here, we set it to
+   Usually, default is set to PHP in Includes.rst.txt. Here, we set it to
    rst (for reStructuredText).
    ------------------------------------------------------------------
 

--- a/Documentation/WritingReST/CleverRest.rst
+++ b/Documentation/WritingReST/CleverRest.rst
@@ -1,5 +1,5 @@
 
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _Clever-reST:

--- a/Documentation/WritingReST/Codeblocks.rst
+++ b/Documentation/WritingReST/Codeblocks.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _writing-rest-codeblocks-with-syntax-highlighting:
@@ -19,7 +19,7 @@ Quick Reference
 * You can explicitly set the language in the `code-block`, you cannot in the shorthand.
 * If you do not explicitly set the language, the default language (as set with
   the :ref:`codeblocks-highlight-directive`) is used. If no highlight directive
-  was used, the default set in :ref:`Includes.txt <includes-txt>` is used.
+  was used, the default set in :ref:`Includes.rst.txt <includes-txt>` is used.
 * It is recommended to use the short form (`::`), and not code-block explicitly.
 * Always use :ref:`syntactically correct code <codeblocks-syntactically-correct>`
   in a code block.
@@ -43,7 +43,7 @@ The following examples all do the same thing:
             $a = 'b';
 
       You can use this, if the default language is already set to PHP with the :ref:`highlight
-      directive <codeblocks-highlight-directive>` in the current file (or in :ref:`Includes.txt
+      directive <codeblocks-highlight-directive>` in the current file (or in :ref:`Includes.rst.txt
       <includes-txt>`).
 
 
@@ -66,7 +66,7 @@ The following examples all do the same thing:
             $a = 'b';
 
       You can use this, if you already set the language PHP with the :ref:`highlight
-      directive <codeblocks-highlight-directive>` in the current file (or in :ref:`Includes.txt
+      directive <codeblocks-highlight-directive>` in the current file (or in :ref:`Includes.rst.txt
       <includes-txt>`).
 
 
@@ -183,7 +183,7 @@ Use codeblock without specifying language::
       $a = 'b';
 
 This uses whatever language has last been set with the :ref:`codeblocks-highlight-directive`
-in the current file or in Includes.txt.
+in the current file or in Includes.rst-txt.
 
 .. _writing-rest-codeblocks-syntactically-correct:
 .. _codeblocks-syntactically-correct:
@@ -251,7 +251,7 @@ Use PHP highlighting::
    .. highlight:: php
 
 For TYPO3 we have adopted the convention that each reStructuredText source file
-imports the :file:`Documentation/Includes.txt` file at the top. And in the
+imports the :file:`Documentation/Includes.rst.txt` file at the top. And in the
 included file - in general - we set PHP as default language for highlighting.
 Exception: In the TypoScript manuals we are using `typoscript` as default.
 

--- a/Documentation/WritingReST/Codeblocks.rst
+++ b/Documentation/WritingReST/Codeblocks.rst
@@ -183,7 +183,7 @@ Use codeblock without specifying language::
       $a = 'b';
 
 This uses whatever language has last been set with the :ref:`codeblocks-highlight-directive`
-in the current file or in Includes.rst-txt.
+in the current file or in :file:`Includes.rst.txt`.
 
 .. _writing-rest-codeblocks-syntactically-correct:
 .. _codeblocks-syntactically-correct:

--- a/Documentation/WritingReST/CodingGuidelines.rst
+++ b/Documentation/WritingReST/CodingGuidelines.rst
@@ -1,5 +1,5 @@
 :orphan:
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 =========================

--- a/Documentation/WritingReST/Comments.rst
+++ b/Documentation/WritingReST/Comments.rst
@@ -1,6 +1,6 @@
 
 
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _writing-rest-comments:

--- a/Documentation/WritingReST/CommonPitfalls.rst
+++ b/Documentation/WritingReST/CommonPitfalls.rst
@@ -1,6 +1,6 @@
 :orphan:
 
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 
 
 

--- a/Documentation/WritingReST/CommonPitfalls/Headers.rst
+++ b/Documentation/WritingReST/CommonPitfalls/Headers.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 

--- a/Documentation/WritingReST/CommonPitfalls/Hyperlinks.rst
+++ b/Documentation/WritingReST/CommonPitfalls/Hyperlinks.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 

--- a/Documentation/WritingReST/CommonPitfalls/Indents.rst
+++ b/Documentation/WritingReST/CommonPitfalls/Indents.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. highlight:: rst
 

--- a/Documentation/WritingReST/CommonPitfalls/Index.rst
+++ b/Documentation/WritingReST/CommonPitfalls/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _rest-common-pitfalls:

--- a/Documentation/WritingReST/CommonPitfalls/InlineStyle.rst
+++ b/Documentation/WritingReST/CommonPitfalls/InlineStyle.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _common-pitfalls-inline-style:

--- a/Documentation/WritingReST/CommonPitfalls/Lists.rst
+++ b/Documentation/WritingReST/CommonPitfalls/Lists.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 

--- a/Documentation/WritingReST/DefinitionLists.rst
+++ b/Documentation/WritingReST/DefinitionLists.rst
@@ -1,5 +1,5 @@
 
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _Styled-Definition-Lists:
@@ -108,7 +108,7 @@ Attention:
 
 The textroles `ascpect` and `sep` (for separator) need to be defined. The usual
 way of defining them is by having these lines in the
-:file:`Documentation/Includes.txt` file. Add these lines::
+:file:`Documentation/Includes.rst.txt` file. Add these lines::
 
    .. role:: aspect (emphasis)
    .. role:: sep (strong)

--- a/Documentation/WritingReST/HeadlinesAndSection.rst
+++ b/Documentation/WritingReST/HeadlinesAndSection.rst
@@ -1,5 +1,5 @@
 
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _Headlines-and-sections:

--- a/Documentation/WritingReST/Hyperlinks.rst
+++ b/Documentation/WritingReST/Hyperlinks.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 

--- a/Documentation/WritingReST/Images.rst
+++ b/Documentation/WritingReST/Images.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 

--- a/Documentation/WritingReST/IncludingFiles.rst
+++ b/Documentation/WritingReST/IncludingFiles.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _including-files:

--- a/Documentation/WritingReST/Index.rst
+++ b/Documentation/WritingReST/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _Formatting-with-reST:

--- a/Documentation/WritingReST/InlineCode.rst
+++ b/Documentation/WritingReST/InlineCode.rst
@@ -1,5 +1,5 @@
 
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _Inline-Code:
@@ -36,7 +36,7 @@ Use Textroles
    ================ ================================================= ============================================ ===
    Role             Source                                            Output                                       Note
    ================ ================================================= ============================================ ===
-   (default)        ```result = (1 + x) * 32```                       `result = (1 + x) * 32`                      This works because in :file:`Includes.txt` we set the default role to ``:code:`...```
+   (default)        ```result = (1 + x) * 32```                       `result = (1 + x) * 32`                      This works because in :file:`Includes.rst.txt` we set the default role to ``:code:`...```
 
    aspect           ``:aspect:`Description:```                        :aspect:`Description:`                       For better optics
    html             ``:html:`<a href="#">```                          :html:`<a href="#">`
@@ -148,7 +148,7 @@ within sentences is *inline code*.
 - has **no** syntax highlighting,
 - does **not** need to be syntactically correct,
 - can be compared to `<span>...</span>` tags in html,
-- and is made up by self-defined names. For example, look at the :file:`../../Includes.txt`
+- and is made up by self-defined names. For example, look at the :file:`../../Includes.rst.txt`
   file to see how `:php:`, `:ts:` are defined.
 
 In contrast, *code-blocks*
@@ -168,11 +168,11 @@ language with the exception of the TypoScript manuals, where `typoscript` is
 the default.
 
 
-Use 'Includes.txt' File
------------------------
+Use 'Includes.rst.txt' File
+---------------------------
 
 In general, the manual you are working on will already contain an
-:ref:`Includes.txt <includes-txt>` file. In that file, the textroles
+:ref:`Includes.rst.txt <includes-txt>` file. In that file, the textroles
 are defined.
 
 You Need Another Textrole for Code Markup?

--- a/Documentation/WritingReST/Introduction.rst
+++ b/Documentation/WritingReST/Introduction.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _writing-rest-introduction:

--- a/Documentation/WritingReST/ListItemsAsButtons.rst
+++ b/Documentation/WritingReST/ListItemsAsButtons.rst
@@ -1,5 +1,5 @@
 
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _list-items-as-buttons:

--- a/Documentation/WritingReST/Lists.rst
+++ b/Documentation/WritingReST/Lists.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _rest-lists:

--- a/Documentation/WritingReST/MenuHierarchy.rst
+++ b/Documentation/WritingReST/MenuHierarchy.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _toctree:

--- a/Documentation/WritingReST/NumberedLists.rst
+++ b/Documentation/WritingReST/NumberedLists.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _numbered-lists:

--- a/Documentation/WritingReST/Orphans.rst
+++ b/Documentation/WritingReST/Orphans.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _rest-orphans:

--- a/Documentation/WritingReST/Reference.rst
+++ b/Documentation/WritingReST/Reference.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _rest-reference:

--- a/Documentation/WritingReST/SpecialCharacters.rst
+++ b/Documentation/WritingReST/SpecialCharacters.rst
@@ -1,5 +1,5 @@
 
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 
 ==================
 Special Characters

--- a/Documentation/WritingReST/SpecialStyles.rst
+++ b/Documentation/WritingReST/SpecialStyles.rst
@@ -1,5 +1,5 @@
 
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 ==============

--- a/Documentation/WritingReST/Tables.rst
+++ b/Documentation/WritingReST/Tables.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 

--- a/Documentation/WritingReST/YoutubeVideos.rst
+++ b/Documentation/WritingReST/YoutubeVideos.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 .. highlight:: rst
 
 .. _youtube-videos:


### PR DESCRIPTION
* Includes.rst.txt should be used instead of Includes.txt
* Use absolute path name when including

Resolves: #159
Related: TYPO3CMS-Reference-CoreApi#1079