### PR TITLE
Write ViewHelper in CamelCase

### DIFF
--- a/Documentation/GeneralConventions/Glossary.rst
+++ b/Documentation/GeneralConventions/Glossary.rst
@@ -241,7 +241,7 @@ TypoScript
 Spelling:
    :ref:`TYPO3 exception <spelling-typo3>`
 
-Viewhelper
+ViewHelper
 ----------
 
 


### PR DESCRIPTION
According to here: https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/GeneralConventions/ContentStyleGuide.html#exceptions-for-specific-typo3-spellings and most other documentation ViewHelper should be written in CamelCase. If it was not it would have to be written in two word: view helper.  What do you think?