### PR TITLE
Remove requirement for sitemap link on start page

### DIFF
--- a/Documentation/GeneralConventions/ExampleTexts.rst
+++ b/Documentation/GeneralConventions/ExampleTexts.rst
@@ -39,7 +39,7 @@ The following should be on the start page, typically in this order:
       author is "Documentation Team", it should be a link to the
       docs team page on typo3.org, not a link to the email address.
 
-*  *required*: Link to sitemap (as button style)
+*  *optional*: Link to sitemap or index (as button style). This is good practice if the menu contains many items.
 
 *  *required*: (in sidebar with title "Contributors:") Link to
    information about contribution, link targets and the shortcut.


### PR DESCRIPTION
Sitemap is in menu. However, if the menu is very long and cluttered (as in "TYPO3 Explained", it might still be a good idea to have a link to the siteamp (or the index, if it exists) on the start page.