### PR TITLE
Add quick links to contribution page

### DIFF
--- a/Documentation/WritingDocsOfficial/Index.rst
+++ b/Documentation/WritingDocsOfficial/Index.rst
@@ -9,6 +9,14 @@
 How to contribute to official documentation
 ===========================================
 
+.. sidebar:: Quicklinks
+
+   * :ref:`reStructuredText cheatsheet <rest-cheat-sheet>`
+   * :ref:`Conventions <conventions>`
+   * :ref:`Render with Docker <rendering-docs>`
+   * :ref:`Typical tasks <docs-official-how-you-can-help>`
+   * `Open issues <https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3ATYPO3-Documentation>`__ (login to GitHub first)
+
 The community is welcome to make changes to the official documentation
 on https://docs.typo3.org. Any help is appreciated!
 
@@ -18,8 +26,10 @@ you go along.
 Your changes will not be visible right away, someone
 must merge them. So, don't worry about breaking something!
 
-If you're stuck at any point, don't hesitate
-to :ref:`ask for help <how-to-get-help>`.
+If you're stuck at any point, don't hesitate to ask for
+:ref:`help <how-to-get-help>`.
+
+**Workflows**
 
 There are 2 different workflows which you can use to make changes.
 Use what you are most comfortable with!
@@ -27,7 +37,8 @@ Use what you are most comfortable with!
 .. tip::
 
    We recommend to try out the :ref:`"Edit on GitHub" workflow <docs-contribute-github-method>`,
-   because it is a way to quickly make changes, but use :ref:`"Local Editing and Rendering
+   because it is a way to quickly make changes, but if you are familiar with
+   working with Git, use :ref:`"Local Editing and Rendering
    with Docker" <docs-contribute-git-docker>` in the long run for larger
    changes.
 
@@ -37,10 +48,7 @@ Use what you are most comfortable with!
 
       You can edit documentation directly online in your browser.
 
-      This workflow can be used for minor changes.
-
-      For extensive changes, it is recommended to use "Local Editing
-      and Rendering with Docker".
+      This workflow can be used for minor changes (e.g. to fix typos).
 
       **Get started:** :ref:`docs-contribute-github-method`.
 


### PR DESCRIPTION
Since this is THE start page for contribution and people may often
look for information besides just the workflow.