### PR TITLE
Improve overall readability of "How To Contribute" chapter

### DIFF
--- a/Documentation/WritingDocsOfficial/GithubMethod.rst
+++ b/Documentation/WritingDocsOfficial/GithubMethod.rst
@@ -4,61 +4,63 @@
 .. _docs-contribute-github-method:
 
 ================================
-Workflow #1: "Edit on GitHub"
+Workflow #1: "Edit in GitHub"
 ================================
 
 .. youtube:: wNxO-aXY5Yw
 
-
-First time contributor? Look at :ref:`contribute` for some general information about
-contributing to TYPO3 documentation.
-
 .. rst-class:: bignums-xxl
 
-1. Get a GitHub account:
+1. Create a GitHub account:
 
-   `Join GitHub <https://github.com/join>`__
+   Visit `Join GitHub <https://github.com/join>`__ and create your account.
 
-2. Find a page that needs fixing:
+   Though not mandatory, the general convention in the TYPO3 community is
+   to set your GitHub name (*not* username) as your full name.
 
-   Pick a manual, for example :ref:`t3start:start` or :ref:`t3install:start`
-   and find a page there, that you want to change.
+2. Find a page that needs improving:
 
-3. Click on "Edit on GitHub":
+   For example, you may have found a misspelling in
+   the :ref:`t3start:start` or you want to add some new content
+   to the :ref:`t3install:start`.
 
-   You should find the button on the top right of any page!
+3. Edit the page in GitHub:
+
+   At the top right of every page you will find an icon that says "Edit me on Github".
+   Selecting this link will take you to that pages repository in GitHub.
 
    .. image:: ../images/edit_me_on_github.png
       :class: with-border with-shadow
 
 4. Fork the repository:
 
-   Click on the green button to fork the repository.
+   Click on the green button to fork the repository. This will clone the repository
+   into your GitHub account, ready for you to make your changes in your browser.
 
    .. image:: ../images/github-edit-fork.png
       :class: with-border with-shadow
 
 5. Make your changes:
 
-   You should now see an edit window where you can make your changes
-   directly. The settings *"Indent mode: Spaces"* and *"Indent size: 3"*
-   should already be correct, by default. Don't change that.
+   You will be presented with a window where you can make your changes.
+   The *"Indent mode: Spaces"* and *"Indent size: 3"*
+   values should already be set - do not alter these.
 
    .. image:: ../images/github-edit-window.png
       :class: with-border with-shadow
 
-6. Handling reST:
 
-   The files are written in reST format. You can :ref:`learn more about reST
-   <rest-quick-start>` when you need it. For fixing simple typos and editing
-   unformatted text, you should be ok without knowledge about reST.
+6. Working with reST files:
 
-7. Check Preview:
+   Every page you edit is written in reST format, when it comes to making minor
+   amendments no prior knowledge of editing .rst files is required. However, when you are
+   ready to make more advanced changes, you can :ref:`learn more about working with reST here.<rest-quick-start>`
 
-   Click on "Preview changes" to see what you changed and how the final result
-   might look like.
+7. Preview your changes:
 
-   Go back to the edit window and make more changes any time.
+   Select "Preview changes" to see what your changes will look like once they are published.
+
+   You can go back and make further changes at any time, select the Edit file tab to continue editing.
 
    .. image:: ../images/github-edit-preview.png
       :class: with-border with-shadow
@@ -66,7 +68,7 @@ contributing to TYPO3 documentation.
 8. Finalize your changes:
 
    When you are ready, scroll down to the bottom of the page. Add
-   a short (!) text describing your changes and click on "Propose
+   a short (but meaningful) description that outlines the changes you have made and click "Propose
    file change"
 
    .. image:: ../images/github-propose-file-changes.png
@@ -74,32 +76,32 @@ contributing to TYPO3 documentation.
 
 9. Create pull request:
 
-   GitHub will now show you an overview of your changes. If this is
-   ok, click on "Create pull request".
+   GitHub will show you an overview of your changes. If you are happy with
+   them, select "Create pull request".
 
    .. image:: ../images/github-comparing-changes.png
       :class: with-border with-shadow
 
-   And finally, create your pull request:
+   Finally, create your pull request:
 
    .. image:: ../images/github-create-pull-request2.png
       :class: with-border with-shadow
 
 10. You're done!
 
-    Well, almost. Your change will now be reviewed. A reviewer might
-    suggest changes. Monitor your notifications (email) from GitHub. If at any
+    Your change will now be reviewed. A reviewer might
+    suggest additional changes. Monitor your notifications (email) from GitHub. If at any
     point, you are not sure what to do, don't hesitate to
     :ref:`ask for help <how-to-get-help>`. When your pull request is accepted,
-    it will be merged. You will get a notification (email).
+    it will be merged. You will receive a notification email as soon as this happens.
 
 
 **Congratulations! You are now a contributor. Welcome and thank you!**
 
-Wait a few minutes for the changes to be automatically rendered, and then
-reload the page (which you fixed) in your browser.
+After a short period your changes will be automatically rendered, reload the page
+and your changes will be visible to everyone.
 
-Next month, you can find your name on the "Developer Appreciation Day"
+Next month, your name will be listed in the "Developer Appreciation Day"
 (DAD) page on the `TYPO3 Blog <https://typo3.com/blog/tag/contribution/>`__.
 
 See `June 2018: Developer Appreciation Day

--- a/Documentation/WritingDocsOfficial/GithubMethod.rst
+++ b/Documentation/WritingDocsOfficial/GithubMethod.rst
@@ -4,7 +4,7 @@
 .. _docs-contribute-github-method:
 
 ================================
-Workflow #1: "Edit in GitHub"
+Workflow #1: "Edit on GitHub"
 ================================
 
 .. youtube:: wNxO-aXY5Yw
@@ -24,10 +24,10 @@ Workflow #1: "Edit in GitHub"
    the :ref:`t3start:start` or you want to add some new content
    to the :ref:`t3install:start`.
 
-3. Edit the page in GitHub:
+3. Edit the page on GitHub:
 
    At the top right of every page you will find an icon that says "Edit me on Github".
-   Selecting this link will take you to that pages repository in GitHub.
+   Selecting this link will take you to that pages repository on GitHub.
 
    .. image:: ../images/edit_me_on_github.png
       :class: with-border with-shadow

--- a/Documentation/WritingDocsOfficial/Index.rst
+++ b/Documentation/WritingDocsOfficial/Index.rst
@@ -30,9 +30,9 @@ There are two different ways in which you can make your changes before submittin
 
 .. rst-class:: bignums
 
-   1. Edit in GitHub
+   1. Edit on GitHub
 
-      You can edit documentation in your browser by accessing its repository directly in GitHub.
+      You can edit documentation in your browser by accessing its repository directly on GitHub.
 
       This workflow is ideal for making minor changes such as fixing grammatical errors and typos.
 

--- a/Documentation/WritingDocsOfficial/Index.rst
+++ b/Documentation/WritingDocsOfficial/Index.rst
@@ -5,9 +5,9 @@
 .. _docs-contribute:
 .. _docs-official-workflow-methods:
 
-===========================================
-How to contribute to official documentation
-===========================================
+=====================================
+Contribute to the TYPO3 documentation
+=====================================
 
 .. sidebar:: Quicklinks
 
@@ -15,57 +15,37 @@ How to contribute to official documentation
    * :ref:`Conventions <conventions>`
    * :ref:`Render with Docker <rendering-docs>`
    * :ref:`Typical tasks <docs-official-how-you-can-help>`
-   * `Open issues <https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3ATYPO3-Documentation>`__ (login to GitHub first)
+   * `Open issues <https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3ATYPO3-Documentation>`__ (a GitHub account is required)
 
-The community is welcome to make changes to the official documentation
-on https://docs.typo3.org. Any help is appreciated!
+Everyone is welcome to make changes and help improve TYPO3's documentation.
 
-You can start with very minimal knowledge and learn as
-you go along.
+No prior knowledge is required and support is always available for new contributors :ref:`here <how-to-get-help>`.
 
-Your changes will not be visible right away, someone
-must merge them. So, don't worry about breaking something!
-
-If you're stuck at any point, don't hesitate to ask for
-:ref:`help <how-to-get-help>`.
+Once you have submitted your changes they won't be visible straight away. Someone in the Documentation Team
+will need to approve the changes first before they are published.
 
 **Workflows**
 
-There are 2 different workflows which you can use to make changes.
-Use what you are most comfortable with!
-
-.. tip::
-
-   We recommend to try out the :ref:`"Edit on GitHub" workflow <docs-contribute-github-method>`,
-   because it is a way to quickly make changes, but if you are familiar with
-   working with Git, use :ref:`"Local Editing and Rendering
-   with Docker" <docs-contribute-git-docker>` in the long run for larger
-   changes.
+There are two different ways in which you can make your changes before submitting them for approval.
 
 .. rst-class:: bignums
 
-   1. "Edit on GitHub" workflow
+   1. Edit in GitHub
 
-      You can edit documentation directly online in your browser.
+      You can edit documentation in your browser by accessing its repository directly in GitHub.
 
-      This workflow can be used for minor changes (e.g. to fix typos).
+      This workflow is ideal for making minor changes such as fixing grammatical errors and typos.
 
-      **Get started:** :ref:`docs-contribute-github-method`.
+      :ref:`docs-contribute-github-method`.
 
-   2. "Local Editing and Rendering with Docker" workflow
+   2. Edit locally and render with Docker
 
-      If you are familiar with Git, Docker and the command line,
-      you can use this workflow. In fact, it is recommended.
+      This method is suited to users who are comfortable using Git, Docker
+      and the command line. It's the recommended approach for making larger
+      changes as it gives you greater control over what tools you use and
+      it also allows you to test and view your changes locally before submitting them for approval.
 
-      If you already contributed to other projects on GitHub via
-      pull requests, you should already be familiar with this workflow.
-      The only difference to a general GitHub contribution workflow
-      using Git is the local rendering with Docker!
-
-      **Get started:** :ref:`docs-contribute-git-docker`
-
-
-
+      :ref:`docs-contribute-git-docker`
 
 
 .. toctree::

--- a/Documentation/WritingDocsOfficial/LocalEditing.rst
+++ b/Documentation/WritingDocsOfficial/LocalEditing.rst
@@ -7,7 +7,7 @@
 Workflow #2: "Local editing and rendering with Docker"
 ======================================================
 
-Using your local machine instead of editing documentation in GitHub has many advantages, it includes
+Using your local machine instead of editing documentation on GitHub has many advantages, it includes
 the freedom to choose which IDE you make your changes in (see :ref:`tools-for-editing-rest`) and it also gives you
 the ability to experiment and preview your changes locally before submitting them for approval.
 

--- a/Documentation/WritingDocsOfficial/LocalEditing.rst
+++ b/Documentation/WritingDocsOfficial/LocalEditing.rst
@@ -7,56 +7,34 @@
 Workflow #2: "Local editing and rendering with Docker"
 ======================================================
 
-This section walks you through contributing to the documentation
-with Git and Docker.
-
-If necessary, ask for help as explained in :ref:`how-to-get-help`.
-
-
-.. _edit-locally-quickstart:
-
-Quick Start
-===========
-
-This describes how to create a pull request for the TYPO3 documentation. All
-steps described are steps you would usually do for any GitHub pull
-request. Only the part about editing (step 6) and rendering (step 7)
-are specific to TYPO3 documentation.
-
+Using your local machine instead of editing documentation in GitHub has many advantages, it includes
+the freedom to choose which IDE you make your changes in (see :ref:`tools-for-editing-rest`) and it also gives you
+the ability to experiment and preview your changes locally before submitting them for approval.
 
 .. rst-class:: bignums-xxl
 
-1. Get a `GitHub <https://github.com>`__ account:
+1. Create a GitHub account:
 
-   Fill out the form on `Join GitHub <https://github.com/join>`__.
+   Visit `Join GitHub <https://github.com/join>`__ and create your account.
 
-   The general convention in the TYPO3 community is to use your full
-   real name as name (*not* username), but it is not a requirement.
-
-   Be sure to use an email-address that you will regularly check as
-   soon as you upload changes to GitHub.
+   Though not mandatory, the general convention in the TYPO3 community is
+   to set your GitHub name (*not* username) as your full name.
 
 2. Find and fork the repository
 
-   Find the repository for the manual you wish to make changes to.
-   In the footer of the rendered documentation on docs.typo3.org,
-   click on the link :guilabel:`Repository`.
+   In the footer of the documentation you wish to make changes to,
+   select the :guilabel:`Repository` link.
 
-   This will direct you to the repository on GitHub.
+   This will take you to the documentations repository in GitHub.
 
-   There, click on the "Fork" button in the upper right.
+   From here, select the "Fork" button in the upper right corner of the page.
 
    .. image:: ../images/github-fork.png
       :class: with-shadow
 
-   .. note::
-      The repository will be forked to your workspace on GitHub. You can
-      delete it later or reuse it for further changes.
-
-
 3. Clone the forked repository
 
-   Clone the **forked repository from your workspace** (click *Clone or
+   Clone the **forked repository from your workspace** (select *Clone or
    download* to copy the URL).
 
    In your terminal:
@@ -68,26 +46,25 @@ are specific to TYPO3 documentation.
 
 4. Setup Git Settings and SSH Key
 
-   For this, we refer to general help on Git or GitHub:
+   For this, we refer to the general help on Git and GitHub:
 
    Setup `username <https://help.github.com/en/articles/setting-your-username-in-git>`__
    and `email <https://help.github.com/en/articles/setting-your-commit-email-address-in-git>`__
    (if not already setup in your global :file:`~/.gitconfig`).
 
-
    `Setup your .ssh key for GitHub <https://help.github.com/en/enterprise/2.15/user/articles/adding-a-new-ssh-key-to-your-github-account>`__
 
-5. Create a branch
+5. Create a branch for your changes
 
 
    .. important::
 
-      If you did not just fork and clone but are using a local repository, you created a while ago:
+      If you did not just fork and clone but are instead using an old local version of this repository:
 
       #. Make sure the repository is up-to-date by pulling from upstream as described
          in :ref:`contribute-edit-locally-more-changes`.
       #. Always branch from *master* (see also :ref:`tip-branches-master`).
-         If you have still checked out a feature branch, switch back to  *master*
+         If you are checked in to a feature branch, switch back to *master*
          first:
 
          .. code-block:: bash
@@ -100,24 +77,21 @@ are specific to TYPO3 documentation.
 
       git checkout -b feature/changes-in-cgl
 
-6. Make changes
+6. Make your changes
 
-   Using your preferred IDE or editor (see :ref:`tools-for-editing-rest`,
-   make changes to the files.
+   Using your preferred IDE or editor you can now start making your changes.
 
-   If you are not familiar with reST, you might want to check out
-   :ref:`reST Introduction <writing-rest-introduction>` first!
-
-   Also, see our :ref:`rest-cheat-sheet` in this guide.
-
+   If you are not familiar with reST, you can visit the
+   :ref:`reST Introduction <writing-rest-introduction>` to help get you started
+   along with the :ref:`rest-cheat-sheet`.
 
 7. Render the documentation
 
-   Render with Docker in order to test the changes:
+   Render your changes with Docker to preview them locally:
 
    *  :ref:`render-documenation-with-docker` (works best on Linux)
    *  :ref:`render-with-docker-compose` (should work better on MacOS
-      or Windows, but is still being tested)
+      and Windows, but is still in development)
 
 8. Commit
 
@@ -125,10 +99,9 @@ are specific to TYPO3 documentation.
 
       git commit -a
 
-   Write a short commit message, describing what was changed, for example
-   "Fix link". See :ref:`general-conventions-commit-messages`, but keep in
-   mind that the conventions for commit messages for the documentation are
-   not strict.
+   Write a short, meaningful commit message describing what changes you have made.
+   See :ref:`general-conventions-commit-messages` for more information on how to
+   word your commit messages.
 
 9. Push changes
 
@@ -148,12 +121,11 @@ are specific to TYPO3 documentation.
     Click on the green button "Compare & pull request" and then
     "Create pull request".
 
-
-Now, wait for someone to review and merge your pull request
-
-
-You will receive notifications (email) about this. Once your change is
-merged, you can reload the page (which you fixed) in your browser.
+    Your change will now be reviewed. A reviewer might
+    suggest additional changes. Monitor your notifications (email) from GitHub. If at any
+    point, you are not sure what to do, don't hesitate to
+    :ref:`ask for help <how-to-get-help>`. When your pull request is accepted,
+    it will be merged. You will receive a notification email as soon as this happens.
 
 **Congratulations! You are now a contributor. Welcome and thank you!**
 
@@ -167,7 +139,7 @@ Next steps
 .. index:: Official documentation; Fork up-to date
 .. _contribute-edit-locally-more-changes:
 
-Keep your local fork up-to date
+Keeping your local fork up-to date
 ===============================
 
 Explanation


### PR DESCRIPTION
The intent of this commit it to better explain how users can contribute to the TYPO3 documentation either by editing pages on GitHub or by pulling down a repository and making the changes locally.
