### PR TITLE
[TASK] Unify top-level domain of dummy urls

### DIFF
--- a/Documentation/WritingReST/CheatSheet.rst
+++ b/Documentation/WritingReST/CheatSheet.rst
@@ -176,14 +176,14 @@ Prevent unintentional linking of simple URLs with the :code:`:samp:` directive:
 
 .. code-block:: rest
 
-   The TYPO3 backend can be accessed via :samp:`https://example.com/typo3` ..
+   The TYPO3 backend can be accessed via :samp:`https://example.org/typo3` ..
 
 and emphasize parts of the URL with curly braces:
 
 .. code-block:: rest
 
    The *route* is the "speaking URL" as a whole without the domain part,
-   for example :samp:`https://example.com{/unlinked-urls}`.
+   for example :samp:`https://example.org{/unlinked-urls}`.
 
 
 .. seealso::

--- a/Documentation/WritingReST/Codeblocks.rst
+++ b/Documentation/WritingReST/Codeblocks.rst
@@ -306,7 +306,7 @@ Source
           $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= ',tx_realurl_pathsegment';
 
           // Adjust to your needs
-          $domain = 'www.example.com';
+          $domain = 'example.org';
           $rootPageUid = 123;
           $rssFeedPageType = 9818; // pageType of your RSS feed page
 
@@ -323,7 +323,7 @@ Result
        $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= ',tx_realurl_pathsegment';
 
        // Adjust to your needs
-       $domain = 'www.example.com';
+       $domain = 'example.org';
        $rootPageUid = 123;
        $rssFeedPageType = 9818; // pageType of your RSS feed page
 

--- a/Documentation/WritingReST/Hyperlinks.rst
+++ b/Documentation/WritingReST/Hyperlinks.rst
@@ -318,27 +318,27 @@ Preventing links
 
 Sphinx automatically converts simple URLs into links. This can be unintentional
 in certain contexts, for example when using a hypothetical domain like
-"example.com" in a tutorial. To prevent linking, the TYPO3 documentation uses
+"example.org" in a tutorial. To prevent linking, the TYPO3 documentation uses
 the :code:`:samp:` directive to wrap the URL.
 
 For example:
 
 .. code-block:: rest
 
-   The TYPO3 backend can be accessed via :samp:`https://example.com/typo3` ..
+   The TYPO3 backend can be accessed via :samp:`https://example.org/typo3` ..
 
 is rendered like:
 
-The TYPO3 backend can be accessed via :samp:`https://example.com/typo3` ..
+The TYPO3 backend can be accessed via :samp:`https://example.org/typo3` ..
 
 To emphasize parts of the URL, use curly braces:
 
 .. code-block:: rest
 
    The *route* is the "speaking URL" as a whole without the domain part,
-   for example :samp:`https://example.com{/unlinked-urls}`.
+   for example :samp:`https://example.org{/unlinked-urls}`.
 
 is rendered like:
 
 The *route* is the "speaking URL" as a whole without the domain part,
-for example :samp:`https://example.com{/unlinked-urls}`.
+for example :samp:`https://example.org{/unlinked-urls}`.


### PR DESCRIPTION
See TYPO3-Documentation/T3DocTeam#165 for details.

This repository was missing in the first run.