### PR TITLE
Add Graphviz graphs docs

### DIFF
--- a/Documentation/BasicPrinciples.rst
+++ b/Documentation/BasicPrinciples.rst
@@ -373,7 +373,7 @@ Third-party extension documentation
 Find the documentation on `Extensions by extension key <https://docs.typo3.org/typo3cms/extensions/Index.html>`__.
 
 For more information about contributing to third party extension documentation or for your own extension, see
-:ref:`contribute-to-3rdparty-extension`. See :ref:`how-to-start-documentation-for-ext` for
+:ref:`contribute-to-3rdparty-extension`. See :ref:`how-to-start-docs-extension` for
 information about starting extension documentation from scratch.
 
 See also :ref:`overview-of-types` for an overview of the issues, source and workflow for various

--- a/Documentation/Changes.rst
+++ b/Documentation/Changes.rst
@@ -1,4 +1,5 @@
 :orphan:
+
 .. include:: /Includes.rst.txt
 .. index:: ! Changes
 .. _changes:

--- a/Documentation/GeneralConventions/DirectoryFilenames.rst
+++ b/Documentation/GeneralConventions/DirectoryFilenames.rst
@@ -459,7 +459,7 @@ Minimal example
 .. _about-file:
 
 About file (for example README.rst)
-============================
+===================================
 
 **optional** (recommended for official TYPO3 documentation)
 

--- a/Documentation/GeneralConventions/ExampleTexts.rst
+++ b/Documentation/GeneralConventions/ExampleTexts.rst
@@ -145,7 +145,7 @@ with the following content:
    :language: rst
 
 
-.. exapmle-menu::
+.. _example-menu:
 
 Menu
 ====

--- a/Documentation/Maintainers/BackportChanges.rst
+++ b/Documentation/Maintainers/BackportChanges.rst
@@ -32,6 +32,7 @@ to work with. If it is possible, apply your changed to the branch `main`.
 Leave a hint about which versions you have tested, for example:
 
 .. code-block:: none
+
    Verified this on 11.5 and 10.4, I suspect it will also still be the case on main. Could
    someone verify this please?
 

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -62,6 +62,7 @@ project_repository   = https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-How
 # official manuals
 # ----------------
 
+t3home         = https://docs.typo3.org/
 h2document     = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
 t3contribute   = https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/
 t3coreapi      = https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/

--- a/Documentation/WritingDocForExtension/FAQ.rst
+++ b/Documentation/WritingDocForExtension/FAQ.rst
@@ -10,7 +10,7 @@ FAQ
 .. rst-class:: panel panel-default
 
 Where is the link to my documentation in the TYPO3 extension repository?
-========================================================
+========================================================================
 
 Short answer: it will take a few hours and up to a day until the documentation for new extensions is linked in the details of your extension in the `TYPO3 Extension Repository (TER) <https://extensions.typo3.org>`__.
 
@@ -198,7 +198,7 @@ Just add this to your :ref:`settings-cfg` and customize it:
    github_repository = TYPO3-Console/TYPO3-Console
 
 If you used the `sample extension <https://github.com/TYPO3-Documentation/TYPO3CMS-Example-ExtensionManual>`__
-and followed the steps in :ref:`how-to-start-documentation-for-ext`, you should actually already have this.
+and followed the steps in :ref:`how-to-start-docs-extension`, you should actually already have this.
 
 Look at the `typo3_console <https://docs.typo3.org/typo3cms/extensions/typo3_console/>`__
 extension for a working example.

--- a/Documentation/WritingDocForExtension/Index.rst
+++ b/Documentation/WritingDocForExtension/Index.rst
@@ -14,7 +14,7 @@ This chapter explains how to write documentation for a new extension.
 
 This guide uses the `example extension manual <https://github.com/TYPO3-Documentation/TYPO3CMS-Example-ExtensionManual>`__
 as a template for starting out. It contains a working navigation panel, a range of example content and adheres to the guidelines
-laid out in the :ref:`GeneralConventions` chapter.
+laid out in the :ref:`general-conventions` chapter.
 
 Rendering the documentation locally
 -----------------------------------

--- a/Documentation/WritingDocsOfficial/HowYouCanHelp.rst
+++ b/Documentation/WritingDocsOfficial/HowYouCanHelp.rst
@@ -143,7 +143,7 @@ issue for it, if you cannot make the changes yourself.
 
 .. tip::
 
-   Usually, there is :ref:`one branch for each major TYPO3 version <t3start:usage-version-selector>`
+   Usually, there is :ref:`one branch for each major TYPO3 version <t3home:usage-version-selector>`
    in a manual. Please focus your
    efforts mostly on the latest `main` branch, to get that up to date and ready!
 

--- a/Documentation/WritingDocsOfficial/LocalEditing.rst
+++ b/Documentation/WritingDocsOfficial/LocalEditing.rst
@@ -140,7 +140,7 @@ Next steps
 .. _contribute-edit-locally-more-changes:
 
 Keeping your local fork up-to date
-===============================
+==================================
 
 Explanation
 -----------
@@ -193,7 +193,7 @@ so next time it is enough to do:
    git pull upstream main
 
 
-Now, continue with step 5 (create branch) in :ref:`edit-locally-quickstart`.
+Now, continue with step 5 (create branch) in the first section of this page.
 
 
 More information

--- a/Documentation/WritingReST/CheatSheet.rst
+++ b/Documentation/WritingReST/CheatSheet.rst
@@ -543,8 +543,8 @@ Source (tip):
          and click on "View page source".
 
 
-:ref:`Diagrams <diagrams>`
-==========================
+:ref:`Diagrams <plantuml-diagrams>`
+===================================
 
 Source:
 

--- a/Documentation/WritingReST/Codeblocks.rst
+++ b/Documentation/WritingReST/Codeblocks.rst
@@ -75,8 +75,8 @@ The following examples all do the same thing:
 
 .. seealso::
 
-   Add a :ref:`diagram <diagrams>` to your code to enrich your documentation
-   and provide a broader view on your solution.
+   Add a :ref:`diagram <plantuml-diagrams>` to your code to enrich your
+   documentation and provide a broader view on your solution.
 
 .. index:: reST; Code block shorthand notation
 .. _codeblock-shorthand:

--- a/Documentation/WritingReST/CodingGuidelines.rst
+++ b/Documentation/WritingReST/CodingGuidelines.rst
@@ -1,4 +1,5 @@
 :orphan:
+
 .. include:: /Includes.rst.txt
 .. highlight:: rst
 

--- a/Documentation/WritingReST/CommonPitfalls/Indents.rst
+++ b/Documentation/WritingReST/CommonPitfalls/Indents.rst
@@ -38,12 +38,12 @@ rendered at all!
 ::
 
    .. image:: ../../images/a4.jpg
-     :width: 100px
+      :width: 100px
       :class: with-shadow
 
 How it looks:
 
 
 .. image:: ../../images/a4.jpg
-  :width: 100px
+   :width: 100px
    :class: with-shadow

--- a/Documentation/WritingReST/Graphs.rst
+++ b/Documentation/WritingReST/Graphs.rst
@@ -1,0 +1,484 @@
+.. include:: /Includes.rst.txt
+.. highlight:: rst
+.. index::
+   ! Graphs
+   Graphs; Graphviz
+.. _graphviz-graphs:
+
+===============
+Graphviz graphs
+===============
+
+In order to render graphs in the TYPO3 documentation,
+`Graphviz <https://graphviz.org/>`_ is integrated into the rendering process.
+
+.. contents::
+   :backlinks: top
+   :class: compact-list
+   :depth: 2
+   :local:
+
+.. _graphviz-graphs-graph-types:
+
+Graph types
+===========
+
+There are two types of graphs to choose from: The directed and the undirected
+graph, which are declared by the keywords `digraph` and `graph` respectively.
+
+.. index:: Graphs types; Undirected graph
+.. _graphviz-graphs-undirected-graph:
+
+Undirected graph
+----------------
+
+.. graphviz::
+   :caption: The MVC pattern divides the application into three global layers.
+
+   graph {
+      user [
+         shape=plaintext;
+         width=4;
+         label="User";
+         style="";
+         # Image is currently not supported due to a bug in Sphinx
+         # see https://github.com/sphinx-doc/sphinx/issues/8232#issuecomment-992711887
+         # image="typo3-logo.svg";
+      ]
+      view [
+         shape=box;
+         width=4;
+         label=<<B>View</B><BR/>Displaying the data>;
+      ]
+      controller [
+         shape=box;
+         width=4;
+         label=<<B>Controller</B><BR/>Control of functionality>;
+      ]
+      model [
+         shape=box;
+         width=4;
+         label=<<B>Model</B><BR/>Domain model and domain logic>;
+      ]
+      user -- view -- controller -- model;
+   }
+
+.. code-block:: rest
+
+   .. graphviz::
+      :caption: The MVC pattern divides the application into three global layers.
+
+      graph {
+         user [
+            shape=plaintext;
+            width=4;
+            label="User";
+            style="";
+            # Image is currently not supported due to a bug in Sphinx
+            # see https://github.com/sphinx-doc/sphinx/issues/8232#issuecomment-992711887
+            # image="typo3-logo.svg";
+         ]
+         view [
+            shape=box;
+            width=4;
+            label=<<B>View</B><BR/>Displaying the data>;
+         ]
+         controller [
+            shape=box;
+            width=4;
+            label=<<B>Controller</B><BR/>Control of functionality>;
+         ]
+         model [
+            shape=box;
+            width=4;
+            label=<<B>Model</B><BR/>Domain model and domain logic>;
+         ]
+         user -- view -- controller -- model;
+      }
+
+Examples: https://graphviz.org/Gallery/undirected/
+
+.. index:: Graphs types; Directed graph
+.. _graphviz-graphs-directed-graph:
+
+Directed graph
+--------------
+
+.. graphviz::
+   :caption: In this request, a list of blog posts is displayed.
+
+   digraph {
+      graph [rankdir=BT;splines=ortho];
+      node [shape=box;width=1];
+
+      user [label="User";shape=plaintext;style="";margin="0.36,0.055"];
+
+      subgraph cluster_view {
+         label="View";
+         style="filled,dashed";
+         v1 [label="V1"];
+         v2 [label="V2";color=grey70;fillcolor=grey90;fontcolor=grey70];
+      }
+
+      subgraph cluster_controller {
+         label="Controller";
+         style="filled,dashed";
+         rankdir=LR;
+
+         subgraph cluster_post_controller {
+            label="PostController";
+            style=filled;
+            list [];
+            show [color=grey70;fillcolor=grey90;fontcolor=grey70];
+         }
+
+         subgraph cluster_comment_controller {
+            label="CommentController";
+            style=filled;
+            color=grey70;
+            fillcolor=grey90;
+            fontcolor=grey70;
+            new [color=grey70;fillcolor=grey90;fontcolor=grey70];
+         }
+      }
+
+      subgraph cluster_model {
+         label="Model";
+         rankdir=LR;
+         style="filled,dashed";
+         blog_entity [label="";shape=ellipse];
+         post_entity [label="";shape=ellipse];
+      }
+
+      blog_entity -> list [label="③ Array of blog posts"];
+      list -> v1 [label="④ Array of blog posts for display"];
+      v1 -> user [label="⑤ Response"];
+      user -> list [label="① Request";constraint=false];
+      list -> blog_entity [label="② Retrieve all blog posts";constraint=false];
+   }
+
+.. code-block:: rest
+
+   .. graphviz::
+      :caption: In this request, a list of blog posts is displayed.
+
+      digraph {
+         graph [rankdir=BT;splines=ortho];
+         node [shape=box;width=1];
+
+         user [label="User";shape=plaintext;style="";margin="0.36,0.055"];
+
+         subgraph cluster_view {
+            label="View";
+            style="filled,dashed";
+            v1 [label="V1"];
+            v2 [label="";style="";shape=plaintext];
+         }
+
+         subgraph cluster_controller {
+            label="Controller";
+            style="filled,dashed";
+            rankdir=LR;
+
+            subgraph cluster_post_controller {
+               label="PostController";
+               style=filled;
+               list [];
+               show [color=grey70;fillcolor=grey90;fontcolor=grey70];
+            }
+
+            subgraph cluster_comment_controller {
+               label="CommentController";
+               style=filled;
+               color=grey70;
+               fillcolor=grey90;
+               fontcolor=grey70;
+               new [color=grey70;fillcolor=grey90;fontcolor=grey70];
+            }
+         }
+
+         subgraph cluster_model {
+            label="Model";
+            rankdir=LR;
+            style="filled,dashed";
+            blog_entity [label="";shape=ellipse];
+            post_entity [label="";shape=ellipse];
+         }
+
+         blog_entity -> list [label="③ Array of blog posts"];
+         list -> v1 [label="④ Array of blog posts for display"];
+         v1 -> user [label="⑤ Response"];
+         user -> list [label="① Request";constraint=false];
+         list -> blog_entity [label="② Retrieve all blog posts";constraint=false];
+      }
+
+Examples: https://graphviz.org/Gallery/directed/
+
+.. _graphviz-graphs-layout-engines:
+
+Layout engines
+==============
+
+The graphs can be rendered using different engines, where the default is
+*Dot*, which is the most popular for directed graphs.
+The engine is defined by the attribute `layout` with the available values
+
+-  :ref:`dot <graphviz-graphs-dot-layout-engine>` (default)
+-  :ref:`neato <graphviz-graphs-neato-layout-engine>`
+-  :ref:`twopi <graphviz-graphs-twopi-layout-engine>`
+-  :ref:`circo <graphviz-graphs-circo-layout-engine>`
+-  :ref:`fdp <graphviz-graphs-fdp-layout-engine>`
+-  :ref:`osage <graphviz-graphs-osage-layout-engine>`
+-  :ref:`patchwork <graphviz-graphs-patchwork-layout-engine>` and
+-  :ref:`sfdp <graphviz-graphs-sfdp-layout-engine>`.
+
+Below you will find some examples of graphs rendered by the available engines.
+
+.. index:: Graphs engines; Dot layout engine
+.. _graphviz-graphs-dot-layout-engine:
+
+Dot layout engine
+-----------------
+
+.. graphviz::
+
+   digraph G {
+      subgraph cluster_0 {
+         style=filled;
+         color=lightgrey;
+         fillcolor=lightgrey;
+         node [color=white;fillcolor=white];
+         a0 -> a1 -> a2 -> a3;
+         label = "process #1";
+      }
+
+      subgraph cluster_1 {
+         b0 -> b1 -> b2 -> b3;
+         label="process #2";
+         color=blue;
+      }
+
+      start -> a0;
+      start -> b0;
+      a1 -> b3;
+      b2 -> a3;
+      a3 -> a0;
+      a3 -> end;
+      b3 -> end;
+
+      start [shape=Mdiamond];
+      end [shape=Msquare];
+   }
+
+.. code-block:: rest
+
+   .. graphviz::
+
+      digraph G {
+         subgraph cluster_0 {
+            style=filled;
+            color=lightgrey;
+            fillcolor=lightgrey;
+            node [color=white;fillcolor=white];
+            a0 -> a1 -> a2 -> a3;
+            label = "process #1";
+         }
+
+         subgraph cluster_1 {
+            b0 -> b1 -> b2 -> b3;
+            label="process #2";
+            color=blue;
+         }
+
+         start -> a0;
+         start -> b0;
+         a1 -> b3;
+         b2 -> a3;
+         a3 -> a0;
+         a3 -> end;
+         b3 -> end;
+
+         start [shape=Mdiamond];
+         end [shape=Msquare];
+      }
+
+Documentation: https://graphviz.org/docs/layouts/dot/
+
+.. index:: Graphs engines; Neato layout engine
+.. _graphviz-graphs-neato-layout-engine:
+
+Neato layout engine
+-------------------
+
+.. graphviz::
+
+   graph ER {
+      layout=neato;
+
+      node [shape=box]; course; institute; student;
+      node [shape=ellipse]; {node [label="name"] name0; name1; name2;}
+         code; grade; number;
+      node [shape=diamond,color=lightgrey,fillcolor=lightgrey]; "C-I"; "S-C"; "S-I";
+
+      name0 -- course;
+      code -- course;
+      course -- "C-I" [label="n",len=1.00];
+      "C-I" -- institute [label="1",len=1.00];
+      institute -- name1;
+      institute -- "S-I" [label="1",len=1.00];
+      "S-I" -- student [label="n",len=1.00];
+      student -- grade;
+      student -- name2;
+      student -- number;
+      student -- "S-C" [label="m",len=1.00];
+      "S-C" -- course [label="n",len=1.00];
+
+      label="\n\nEntity Relation Diagram\ndrawn by NEATO";
+      fontsize=20;
+   }
+
+.. code-block:: rest
+
+   .. graphviz::
+
+      graph ER {
+         layout=neato;
+
+         node [shape=box]; course; institute; student;
+         node [shape=ellipse]; {node [label="name"] name0; name1; name2;}
+            code; grade; number;
+         node [shape=diamond,color=lightgrey,fillcolor=lightgrey]; "C-I"; "S-C"; "S-I";
+
+         name0 -- course;
+         code -- course;
+         course -- "C-I" [label="n",len=1.00];
+         "C-I" -- institute [label="1",len=1.00];
+         institute -- name1;
+         institute -- "S-I" [label="1",len=1.00];
+         "S-I" -- student [label="n",len=1.00];
+         student -- grade;
+         student -- name2;
+         student -- number;
+         student -- "S-C" [label="m",len=1.00];
+         "S-C" -- course [label="n",len=1.00];
+
+         label="\n\nEntity Relation Diagram\ndrawn by NEATO";
+         fontsize=20;
+      }
+
+Documentation: https://graphviz.org/docs/layouts/neato/
+
+.. index:: Graphs engines; Twopi layout engine
+.. _graphviz-graphs-twopi-layout-engine:
+
+Twopi layout engine
+-------------------
+
+The given examples of the Graphviz gallery are too large for inclusion here.
+In case you can contribute one, feel encouraged to get in contact with us.
+Navigate to the below URLs to get further insights.
+
+*  Documentation: https://graphviz.org/docs/layouts/twopi/
+*  Example: https://graphviz.org/Gallery/undirected/networkmap_twopi.html
+
+.. index:: Graphs engines; Circo layout engine
+.. _graphviz-graphs-circo-layout-engine:
+
+Circo layout engine
+-------------------
+
+No examples provided at the Graphviz gallery for this layout engine.
+In case you can contribute one, feel encouraged to get in contact with us.
+Navigate to the below URL to get further insights.
+
+Documentation: https://graphviz.org/docs/layouts/circo/
+
+.. index:: Graphs engines; Fdp layout engine
+.. _graphviz-graphs-fdp-layout-engine:
+
+Fdp layout engine
+-----------------
+
+.. graphviz::
+
+   graph G {
+      layout=fdp;
+
+      e;
+
+      subgraph clusterA {
+         a -- b;
+         subgraph clusterC {
+            C -- D;
+         }
+      }
+
+      subgraph clusterB {
+         d -- f;
+      }
+
+      d -- D;
+      e -- clusterB;
+      clusterC -- clusterB;
+   }
+
+.. code-block:: rest
+
+   .. graphviz::
+
+      graph G {
+         layout=fdp;
+
+         e;
+
+         subgraph clusterA {
+            a -- b;
+            subgraph clusterC {
+               C -- D;
+            }
+         }
+
+         subgraph clusterB {
+            d -- f;
+         }
+
+         d -- D;
+         e -- clusterB;
+         clusterC -- clusterB;
+      }
+
+.. index:: Graphs engines; Osage layout engine
+.. _graphviz-graphs-osage-layout-engine:
+
+Osage layout engine
+-------------------
+
+No examples provided at the Graphviz gallery for this layout engine.
+In case you can contribute one, feel encouraged to get in contact with us.
+Navigate to the below URL to get further insights.
+
+Documentation: https://graphviz.org/docs/layouts/osage/
+
+.. index:: Graphs engines; Patchwork layout engine
+.. _graphviz-graphs-patchwork-layout-engine:
+
+Patchwork layout engine
+-----------------------
+
+No examples provided at the Graphviz gallery for this layout engine.
+In case you can contribute one, feel encouraged to get in contact with us.
+Navigate to the below URL to get further insights.
+
+Documentation: https://graphviz.org/docs/layouts/patchwork/
+
+.. index:: Graphs engines; Sfdp layout engine
+.. _graphviz-graphs-sfdp-layout-engine:
+
+Sfdp layout engine
+------------------
+
+No examples provided at the Graphviz gallery for this layout engine.
+In case you can contribute one, feel encouraged to get in contact with us.
+Navigate to the below URL to get further insights.
+
+Documentation: https://graphviz.org/docs/layouts/sfdp/

--- a/Documentation/WritingReST/Reference.rst
+++ b/Documentation/WritingReST/Reference.rst
@@ -28,6 +28,7 @@ reST & Sphinx reference
    Comments
    Tables
    SpecialCharacters
+   Graphs
    Diagrams
    Orphans
    CleverRest


### PR DESCRIPTION
This is how it looks like, as soon as the [default Graphviz styles](https://github.com/t3docs/docker-render-documentation/pull/123) have been merged into the rendering docker image.

![image](https://user-images.githubusercontent.com/20297232/146371078-33b47d4e-89a9-4b23-8340-03be58736fe7.png)

Related to: https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument/issues/252