### PR TITLE
[TASK] Remove old wiki links

### DIFF
--- a/Documentation/BasicPrinciples.rst
+++ b/Documentation/BasicPrinciples.rst
@@ -285,20 +285,6 @@ can also make changes via :ref:`"Edit on GitHub" <docs-contribute-github-method>
 To find out how to contribute documentation for a specific extension:
 :ref:`contribute-to-3rdparty-extension`
 
-
-.. index:: Wiki
-
-What about the Wiki?
---------------------
-
-In this manual, we are focusing on TYPO3 documentation in reST / sphinx
-that can be found on docs.typo3.org.
-
-The TYPO3 Wiki on https://wiki.typo3.org does contain documentation as well,
-but that is not the scope of this manual. In any case, most of the information
-from the Wiki is being moved from the Wiki to some manual on docs.typo3.org.
-
-
 .. index:: Extensions
 .. _about-typo3-extensions:
 

--- a/Documentation/GeneralConventions/ReviewInformation.rst
+++ b/Documentation/GeneralConventions/ReviewInformation.rst
@@ -12,10 +12,6 @@ Reviewing manuals and finding a workflow for this is still a work in progress.
 See the :ref:`Related Issues <review-workflow-related-issues>`.
 
 
-An overview of all manual maintainers and review status is maintained
-in the `Wiki <https://wiki.typo3.org/DocTeam/Official_Documentation_Maintenance>`__.
-
-
 .. index:: Reviewing manuals; Guidelines
 
 Guidelines for reviewing
@@ -35,7 +31,7 @@ Guidelines for reviewing
 
 What to watch out for while reviewing:
 
-*  **Duplicate content:** Check for similar content in other manuals (and the TYPO3 Wiki).
+*  **Duplicate content:** Check for similar content in other manuals.
    Merge duplicate content: Decide where the content should live, remove it in the
    other places and add links.
 *  **Remove redundant content:** Keep content short and to the point.

--- a/Documentation/WritingReST/BasicRestSyntax.rst
+++ b/Documentation/WritingReST/BasicRestSyntax.rst
@@ -7,11 +7,6 @@
 Basic reST & Sphinx syntax
 ==========================
 
-.. note::
-
-   Some of this text was taken from the Wiki page:
-   https://wiki.typo3.org/ReST_Syntax
-
 The .rst files are written in reStructuredText (reST) format. They
 contain text with additional markup.
 


### PR DESCRIPTION
and references to the non-existant typo3 wiki

refs https://github.com/TYPO3-Documentation/T3DocTeam/issues/170

releases: main