### PR TITLE
Lets not use :ts: for typoscript

### DIFF
--- a/Documentation/GeneralConventions/FileStructure.rst
+++ b/Documentation/GeneralConventions/FileStructure.rst
@@ -403,8 +403,6 @@ markup languages used in a TYPO3 project:
    .. role:: rst(code)
    .. role:: sep(strong)
    .. role:: sql(code)
-   .. role:: ts(code)
-      :class: typoscript
 
    .. role:: tsconfig(code)
       :class: typoscript


### PR DESCRIPTION
In code blocks `.. code-block:: ts` is used for typescript as a sphinx standard. code-blocks with code-type ts may therefore not contain typoscript or code highlighting will fail. the practice of using `:ts:` for inline code-blocks creates an unnecessary confusion as ppl will then also use it for code-blocks. This has caused missing syntax highlighting and rendering warnings throughout the different documentations.

Unfortunary I didn't catch this in the first review of this document