### PR TITLE
[DOCS] Update TYPO3 documentation standards

### DIFF
--- a/Documentation/GeneralConventions/FileStructure.rst
+++ b/Documentation/GeneralConventions/FileStructure.rst
@@ -928,3 +928,16 @@ PHP application documentation
    Tailor (single)     `README.md <https://github.com/TYPO3/tailor>`__ |
                        `Read online <https://docs.typo3.org/other/typo3/tailor/main/en-us/>`__
    ==================  =========================================================
+
+.. seealso::
+
+   Although it is possible to write every single line of a full documentation
+   from scratch, the TYPO3 community provides tools to support you:
+
+   *  A `sample manual <https://github.com/TYPO3-Documentation/TYPO3CMS-Example-ExtensionManual>`__
+      is available to be immediately copied into your own extension.
+   *  The `Extension Builder <https://extensions.typo3.org/extension/extension_builder>`__
+      optionally generates a sample documentation together with the extension
+      skeleton.
+   *  TYPO3 Core developers use the `ReST Helper <https://forger.typo3.com/utilities/rst>`__
+      to kickoff a new TYPO3 changelog entry.

--- a/Documentation/GeneralConventions/FileStructure.rst
+++ b/Documentation/GeneralConventions/FileStructure.rst
@@ -399,6 +399,7 @@ markup languages used in a TYPO3 project:
 
    .. role:: aspect(emphasis)
    .. role:: bash(code)
+   .. role:: css(code)
    .. role:: html(code)
    .. role:: js(code)
    .. role:: php(code)

--- a/Documentation/GeneralConventions/FileStructure.rst
+++ b/Documentation/GeneralConventions/FileStructure.rst
@@ -549,7 +549,12 @@ properties are in the correct section!
    # ext_felogin        = https://docs.typo3.org/c/typo3/cms-felogin/main/en-us/
    # ext_form           = https://docs.typo3.org/c/typo3/cms-form/main/en-us/
    # ext_fsc            = https://docs.typo3.org/c/typo3/cms-fluid-styled-content/main/en-us/
+   # ext_impexp         = https://docs.typo3.org/c/typo3/cms-impexp/main/en-us/
    # ext_indexed_search = https://docs.typo3.org/c/typo3/cms-indexed-search/main/en-us/
+   # ext_linkvalidator  = https://docs.typo3.org/c/typo3/cms-linkvalidator/main/en-us/
+   # ext_lowlevel       = https://docs.typo3.org/c/typo3/cms-lowlevel/main/en-us/
+   # ext_recycler       = https://docs.typo3.org/c/typo3/cms-recycler/main/en-us/
+   # ext_redirects      = https://docs.typo3.org/c/typo3/cms-redirects/main/en-us/
    # ext_rte_ckeditor   = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/main/en-us/
    # ext_scheduler      = https://docs.typo3.org/c/typo3/cms-scheduler/main/en-us/
    # ext_seo            = https://docs.typo3.org/c/typo3/cms-seo/main/en-us/

--- a/Documentation/GeneralConventions/FileStructure.rst
+++ b/Documentation/GeneralConventions/FileStructure.rst
@@ -109,7 +109,7 @@ example:
    <abstract>
 
    :Repository:  https://<vcs-repository>
-   :Read online: https://docs.typo3.org/p/<vendor>/<extension-key>/main/en-us/
+   :Read online: https://docs.typo3.org/p/<package-name>/main/en-us/
    :TER:         https://extensions.typo3.org/extension/<extension-key>/
 
 or as README.md alternatively:
@@ -123,7 +123,7 @@ or as README.md alternatively:
    |                  | URL                                                           |
    |------------------|---------------------------------------------------------------|
    | **Repository:**  | https://<vcs-repository>                                      |
-   | **Read online:** | https://docs.typo3.org/p/<vendor>/<extension-key>/main/en-us/ |
+   | **Read online:** | https://docs.typo3.org/p/<package-name>/main/en-us/           |
    | **TER:**         | https://extensions.typo3.org/extension/<extension-key>/       |
 
 
@@ -622,8 +622,8 @@ of the TYPO3 world the values:
 #. `since <creation-year> by the TYPO3 contributors`,
    e.g. "since 1999 by the TYPO3 contributors" (official TYPO3 manuals and TYPO3
    system extensions)
-#. `since <creation-year> by <vendor>`,
-   e.g. "since 1999 by the contributors" (third-party TYPO3 extensions)
+#. `since <creation-year> by <vendor> & contributors`,
+   e.g. "since 1999 by dkd & contributors" (third-party TYPO3 extensions)
 
 
 .. _settings-cfg-github-workflow:
@@ -791,7 +791,7 @@ to the next steps, for example
    ..
 
    :Repository:  https://<vcs-repository>
-   :Read online: https://docs.typo3.org/p/<vendor>/<extension-key>/main/en-us/
+   :Read online: https://docs.typo3.org/p/<package-name>/main/en-us/
    :TER: https://extensions.typo3.org/extension/<extension-key>/
 
 or as README.md alternatively:
@@ -814,7 +814,7 @@ or as README.md alternatively:
    |                  | URL                                                           |
    |------------------|---------------------------------------------------------------|
    | **Repository:**  | https://<vcs-repository>                                      |
-   | **Read online:** | https://docs.typo3.org/p/<vendor>/<extension-key>/main/en-us/ |
+   | **Read online:** | https://docs.typo3.org/p/<package-name>/main/en-us/           |
    | **TER:**         | https://extensions.typo3.org/extension/<extension-key>/       |
 
 For more details, see the explanation of :ref:`README.rst <readme-rst>` in the

--- a/Documentation/GeneralConventions/FileStructure.rst
+++ b/Documentation/GeneralConventions/FileStructure.rst
@@ -102,6 +102,8 @@ example:
 
 .. code-block:: rst
 
+   <badges>
+
    =========
    <project>
    =========
@@ -116,6 +118,8 @@ or as README.md alternatively:
 
 .. code-block:: md
 
+   <badges>
+
    # <project>
 
    <abstract>
@@ -125,6 +129,45 @@ or as README.md alternatively:
    | **Repository:**  | https://<vcs-repository>                                      |
    | **Read online:** | https://docs.typo3.org/p/<package-name>/main/en-us/           |
    | **TER:**         | https://extensions.typo3.org/extension/<extension-key>/       |
+
+
+.. _readme-rst-badges:
+
+Badges
+^^^^^^
+
+Point out interesting statistics of your extension or package in the *badges*
+placeholder, which should include the latest release version, the total and
+monthly download rate and the supported TYPO3 versions:
+
+.. code-block:: rst
+
+   .. image:: https://poser.pugx.org/<package-name>/v/stable
+      :alt: Latest Stable Version
+      :target: https://extensions.typo3.org/extension/<extension-key>/
+
+   .. image:: https://img.shields.io/badge/TYPO3-11-orange.svg
+      :alt: TYPO3 11
+      :target: https://get.typo3.org/version/11
+
+   .. image:: https://poser.pugx.org/<package-name>/d/total
+      :alt: Total Downloads
+      :target: https://packagist.org/packages/<package-name>
+
+   .. image:: https://poser.pugx.org/<package-name>/d/monthly
+      :alt: Monthly Downloads
+      :target: https://packagist.org/packages/<package-name>
+
+or for the README.md alternatively:
+
+.. code-block:: md
+
+   [![Latest Stable Version](https://poser.pugx.org/<package-name>/v/stable)](https://extensions.typo3.org/extension/<extension-key>/)
+   [![TYPO3 11](https://img.shields.io/badge/TYPO3-11-orange.svg?style=flat-square)](https://get.typo3.org/version/11)
+   [![Total Downloads](https://poser.pugx.org/<package-name>/d/total)](https://packagist.org/packages/<package-name>)
+   [![Monthly Downloads](https://poser.pugx.org/<package-name>/d/monthly)](https://packagist.org/packages/<package-name>)
+
+Remove this field if the project is no extension or package.
 
 
 .. _readme-rst-project:
@@ -772,6 +815,8 @@ to the next steps, for example
 
 .. code-block:: rst
 
+   <badges>
+
    =========
    <project>
    =========
@@ -797,6 +842,8 @@ to the next steps, for example
 or as README.md alternatively:
 
 .. code-block:: md
+
+   <badges>
 
    # <project>
 

--- a/Documentation/GeneralConventions/FileStructure.rst
+++ b/Documentation/GeneralConventions/FileStructure.rst
@@ -391,7 +391,7 @@ markup languages used in a TYPO3 project:
 .. code-block:: rst
 
    .. More information about this file:
-      https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/GeneralConventions/FileStructure.html#includes-rst-txt
+   .. https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/GeneralConventions/FileStructure.html#includes-rst-txt
 
    .. ----------
    .. text roles


### PR DESCRIPTION
This PR is a follow-up of PR #266 and updates the recently introduced [TYPO3 documentation standards](https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/GeneralConventions/FileStructure.html) with standards that have been created during the standard runs across many manuals of the TYPO3 community, see

* https://github.com/TYPO3-Documentation/T3DocTeam/issues/181
* https://github.com/TYPO3-Documentation/T3DocTeam/issues/182
* https://github.com/TYPO3-Documentation/T3DocTeam/issues/185

Fixes: #274 