### PR TITLE
[DOCS] Integrate new page "User's round trip"

### DIFF
--- a/Documentation/BasicPrinciples.rst
+++ b/Documentation/BasicPrinciples.rst
@@ -82,6 +82,7 @@ creating the menu, using the current theme to add additional styles and images.
 
 
 .. index::  TYPO3 documentation; Types
+.. _documentation-types:
 
 Documentation types
 ===================

--- a/Documentation/BasicPrinciples.rst
+++ b/Documentation/BasicPrinciples.rst
@@ -82,7 +82,6 @@ creating the menu, using the current theme to add additional styles and images.
 
 
 .. index::  TYPO3 documentation; Types
-.. _documentation-types:
 
 Documentation types
 ===================

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -109,6 +109,7 @@ More: :ref:`What's new in this guide ... <whats-new>`
    BasicPrinciples
    GeneralConventions/Index
    WritingReST/Index
+   UserRoundTrip
 
 .. toctree::
    :hidden:

--- a/Documentation/UserRoundTrip.rst
+++ b/Documentation/UserRoundTrip.rst
@@ -1,0 +1,339 @@
+.. include:: /Includes.rst.txt
+
+.. _user-round-trip:
+
+=================
+User's round trip
+=================
+
+Once the user is interested in a TYPO3 extension, a Composer package or a
+standalone manual, they should be quickly directed to all aspects of the
+project: the rendered documentation, the code repository, and the TYPO3
+Extension Repository (TER) and Packagist store pages from which the extension
+or package can be downloaded and installed. Therefore, set up a convenient
+navigation from one aspect to another by using native configuration settings.
+
+.. uml::
+
+   !include <tupadr3/font-awesome-5/typo3>
+
+   skinparam DefaultTextAlignment center
+   skinparam RectangleBackgroundColor transparent
+   skinparam RectangleBorderColor transparent
+   skinparam UsecaseFontColor<< inactive >> #b9b9b9
+   skinparam UsecaseBorderColor<< inactive >> #b9b9b9
+   skinparam UsecaseBackgroundColor<< inactive >> #FEFEFE
+
+   rectangle "<color:#f49700><$typo3></color>\n Extension / Package / Manual" as typo3actor
+   usecase "Packagist" as packagist
+   usecase "VCS repository" as vcsRepository
+   usecase "Documentation" as documentation
+   usecase "TYPO3 Extension Repository" as ter
+
+   typo3actor -left-> packagist
+   typo3actor -right-> vcsRepository
+   typo3actor -up-> documentation
+   typo3actor -down-> ter
+
+   packagist <-up-> documentation
+   documentation <-down-> vcsRepository
+   vcsRepository <-down-> ter
+   ter <-up-> packagist
+
+   hide << inactive >> stereotype
+
+**Table of Contents:**
+
+.. contents::
+   :backlinks: top
+   :class: compact-list
+   :depth: 2
+   :local:
+
+
+.. _user-round-trip-project-aspects:
+
+Project aspects
+===============
+
+
+.. _user-round-trip-documentation-aspect:
+
+Documentation
+-------------
+
+Guide the user from the documentation to the other aspects by setting these
+Sphinx theme configuration properties at :ref:`settings-cfg`:
+
+.. code-block:: none
+
+   project_home         = <typo3-extension-repository>
+   project_repository   = <vcs-repository>
+   project_issues       = <vcs-repository-issues>
+
+for example for the *News System* extension:
+
+.. code-block:: none
+
+   project_home         = https://extensions.typo3.org/extension/news/
+   project_repository   = https://github.com/georgringer/news
+   project_issues       = https://github.com/georgringer/news/issues
+
+and find the links to the other aspects displayed in the footer of the rendered
+documentation (see `News System example <https://docs.typo3.org/p/georgringer/news/main/en-us/>`__).
+
+For a Composer package, replace the TER URL with the Packagist URL. For a
+standalone manual, replace the TER URL with the documentation URL.
+
+The Packagist URL is linked indirectly from the TER page and is therefore not
+specified in this configuration file. The issues URL is considered here because
+it is closely related to the VCS repository aspect.
+
+
+.. _user-round-trip-vcs-repository-aspect:
+
+VCS repository
+--------------
+
+Guide the user from the VCS repository page to the other aspects by offering a
+table in the :ref:`README file <readme-rst>`:
+
+.. code-block:: md
+
+   |                  | URL                                            |
+   |------------------|------------------------------------------------|
+   | **Repository:**  | <vcs-repository>                               |
+   | **Read online:** | <documentation>                                |
+   | **TER:**         | <typo3-extension-repository>                   |
+
+for example for the *Mask* extension:
+
+.. code-block:: md
+
+   |                  | URL                                            |
+   |------------------|------------------------------------------------|
+   | **Repository:**  | https://github.com/Gernott/mask                |
+   | **Read online:** | https://docs.typo3.org/p/mask/mask/main/en-us/ |
+   | **TER:**         | https://extensions.typo3.org/extension/mask    |
+
+and find the README file usually displayed by the VCS host below the file list
+of the repository (see `Mask example <https://github.com/Gernott/mask>`__).
+
+For a Composer package, replace the TER URL with the Packagist URL and label it
+"Packagist:". For a standalone manual, remove the TER entry.
+
+The Packagist URL is linked indirectly from the TER page and is therefore not
+included in this configuration file.
+
+
+.. _user-round-trip-packagist-aspect:
+
+Packagist
+---------
+
+Guide the user from the Packagist page to the other aspects by setting these
+:file:`composer.json` configuration values:
+
+.. code-block:: none
+
+    "homepage": "<typo3-extension-repository>",
+    "support": {
+        "docs": "<documentation>",
+        "issues": "<vcs-repository-issues>",
+        "source": "<vcs-repository>"
+    }
+
+for example for the *Address List* extension:
+
+.. code-block:: none
+
+   "homepage": "https://extensions.typo3.org/extension/tt_address",
+   "support": {
+      "docs": "https://docs.typo3.org/p/friendsoftypo3/tt-address/main/en-us/",
+      "issues": "https://github.com/FriendsOfTYPO3/tt_address/issues",
+      "source": "https://github.com/FriendsOfTYPO3/tt_address"
+   }
+
+and find the links to the other aspects shown in the right column of the
+Packagist page (see `Address List example <https://packagist.org/packages/friendsoftypo3/tt-address>`__).
+
+For a Composer package, replace the TER URL with the Packagist URL.
+
+The issues URL is considered here because it is closely related to the VCS
+repository aspect.
+
+
+.. _user-round-trip-ter-aspect:
+
+TYPO3 Extension Repository
+--------------------------
+
+Guide the user from the TER page to the other aspects by setting these
+configuration values on the
+`extension management page <https://extensions.typo3.org/my-extensions>`__:
+
+*  **Published on Packagist:** check
+*  **Composer name of extension:** `<package-name>`
+*  **Link to issue tracker:** `<vcs-repository-issues>`
+*  **Link to repository:** `<vcs-repository>`
+
+for example for the *Static File Cache* extension:
+
+*  **Published on Packagist:** check
+*  **Composer name of extension:** lochmueller/staticfilecache
+*  **Link to issue tracker:** \https://github.com/lochmueller/staticfilecache/issues
+*  **Link to repository:** \https://github.com/lochmueller/staticfilecache
+
+and find the links to the other aspects presented in the right column of the TER
+page (see `Static File Cache example <https://extensions.typo3.org/extension/staticfilecache>`__).
+
+The documentation URL is automatically resolved when the documentation is
+published on docs.typo3.org. The issues URL is considered here because it is
+closely related to the VCS repository aspect.
+
+
+.. _user-round-trip-project-types:
+
+Project types
+=============
+
+
+.. _user-round-trip-typo3-extension-type:
+
+TYPO3 extension
+---------------
+
+.. uml::
+
+   !include <tupadr3/font-awesome-5/typo3>
+
+   skinparam DefaultTextAlignment center
+   skinparam RectangleBackgroundColor transparent
+   skinparam RectangleBorderColor transparent
+   skinparam UsecaseFontColor<< inactive >> #b9b9b9
+   skinparam UsecaseBorderColor<< inactive >> #b9b9b9
+   skinparam UsecaseBackgroundColor<< inactive >> #FEFEFE
+
+   rectangle "<color:#f49700><$typo3></color>\n TYPO3 extension" as typo3actor
+   usecase "Packagist" as packagist
+   usecase "VCS repository" as vcsRepository
+   usecase "Documentation" as documentation
+   usecase "TYPO3 Extension Repository" as ter
+
+   typo3actor -left-> packagist
+   typo3actor -right-> vcsRepository
+   typo3actor -up-> documentation
+   typo3actor -down-> ter
+
+   packagist <-up-> documentation
+   documentation <-down-> vcsRepository
+   vcsRepository <-down-> ter
+   ter <-up-> packagist
+
+   hide << inactive >> stereotype
+
+Guide the user to all four aspects of the TYPO3 extension, which is usually
+hosted on both TER and Packagist, by configuring:
+
+#. :ref:`user-round-trip-documentation-aspect`
+#. :ref:`user-round-trip-vcs-repository-aspect`
+#. :ref:`user-round-trip-ter-aspect`
+#. :ref:`user-round-trip-packagist-aspect`
+
+For example, look at the *Apache Solr* extension and try navigating all four
+aspects by simply clicking on a redirect link on each page - starting at the
+`Apache Solr TER page <https://extensions.typo3.org/extension/solr>`__.
+
+
+.. _user-round-trip-composer-package-type:
+
+Composer package
+----------------
+
+.. uml::
+
+   !include <tupadr3/font-awesome-5/typo3>
+
+   skinparam DefaultTextAlignment center
+   skinparam RectangleBackgroundColor transparent
+   skinparam RectangleBorderColor transparent
+   skinparam UsecaseFontColor<< inactive >> #b9b9b9
+   skinparam UsecaseBorderColor<< inactive >> #b9b9b9
+   skinparam UsecaseBackgroundColor<< inactive >> #FEFEFE
+
+   rectangle "<color:#f49700><$typo3></color>\n Composer package" as typo3actor
+   usecase "Packagist" as packagist
+   usecase "VCS repository" as vcsRepository
+   usecase "Documentation" as documentation
+   usecase "TYPO3 Extension Repository" << inactive >> as ter
+
+   typo3actor -left-> packagist
+   typo3actor -right-> vcsRepository
+   typo3actor -up-> documentation
+   typo3actor -[hidden]down-> ter
+
+   packagist <-up-> documentation
+   documentation <-down-> vcsRepository
+   vcsRepository <-[hidden]down-> ter
+   ter <-[hidden]up-> packagist
+
+   hide << inactive >> stereotype
+
+A Composer package that is not a TYPO3 extension is usually hosted only on
+Packagist. Therefore, guide the user to three aspects of the package by
+configuring:
+
+#. :ref:`user-round-trip-documentation-aspect`
+#. :ref:`user-round-trip-vcs-repository-aspect`
+#. :ref:`user-round-trip-packagist-aspect`
+
+For example, examine the *TYPO3 Console* package and try navigating through its
+three aspects by just clicking on a redirecting link on each page - starting at
+the `TYPO3 Console Packagist page <https://packagist.org/packages/helhum/typo3-console>`__.
+
+
+.. _user-round-trip-standalone-manual-type:
+
+Standalone manual
+-----------------
+
+.. uml::
+
+   !include <tupadr3/font-awesome-5/typo3>
+
+   skinparam DefaultTextAlignment center
+   skinparam RectangleBackgroundColor transparent
+   skinparam RectangleBorderColor transparent
+   skinparam UsecaseFontColor<< inactive >> #b9b9b9
+   skinparam UsecaseBorderColor<< inactive >> #b9b9b9
+   skinparam UsecaseBackgroundColor<< inactive >> #FEFEFE
+
+   rectangle "<color:#f49700><$typo3></color>\n Standalone manual" as typo3actor
+   usecase "Packagist" << inactive >> as packagist
+   usecase "VCS repository" as vcsRepository
+   usecase "Documentation" as documentation
+   usecase "TYPO3 Extension Repository" << inactive >> as ter
+
+   typo3actor -[hidden]left-> packagist
+   typo3actor -right-> vcsRepository
+   typo3actor -up-> documentation
+   typo3actor -[hidden]down-> ter
+
+   packagist <-[hidden]up-> documentation
+   documentation <-down-> vcsRepository
+   vcsRepository <-[hidden]down-> ter
+   ter <-[hidden]up-> packagist
+
+   hide << inactive >> stereotype
+
+A standalone manual, i.e. a tutorial, guide or reference, is usually not
+hosted in a store. Therefore, guide the user to two aspects of the manual by
+configuring:
+
+#. :ref:`user-round-trip-documentation-aspect`
+#. :ref:`user-round-trip-vcs-repository-aspect`
+
+For example, take a look at the *Getting Started* tutorial and try navigating
+between the two aspects by simply clicking on a redirecting link on each page -
+starting at the
+`Getting Started documentation <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/>`__.

--- a/Documentation/UserRoundTrip.rst
+++ b/Documentation/UserRoundTrip.rst
@@ -8,9 +8,15 @@ User's round trip
 
 Once the user is interested in a TYPO3 extension, a Composer package or a
 standalone manual, they should be quickly directed to all aspects of the
-project: the rendered documentation, the code repository, and the TYPO3
-Extension Repository (TER) and Packagist store pages from which the extension
-or package can be downloaded and installed. Therefore, set up a convenient
+project: 
+
+*  Rendered documentation
+*  Code repository (Github, Gitlab etc)
+*  Packagist
+*  TYPO3 Extension Repository (TER)
+*  Where to report issues
+
+Therefore, set up a convenient
 navigation from one aspect to another by using native configuration settings.
 
 .. uml::

--- a/Documentation/UserRoundTrip.rst
+++ b/Documentation/UserRoundTrip.rst
@@ -6,7 +6,7 @@
 User's round trip
 =================
 
-When a user wants to find out more about a Composer package or a
+When a user wants to find out more about a TYPO3 extension, Composer package or a
 standalone manual, they should be provided with information about every aspect of the
 project including its rendered documentation, code repository and the Packagist and
 TYPO3 Extension Repository (TER) pages.

--- a/Documentation/UserRoundTrip.rst
+++ b/Documentation/UserRoundTrip.rst
@@ -8,15 +8,9 @@ User's round trip
 
 Once the user is interested in a TYPO3 extension, a Composer package or a
 standalone manual, they should be quickly directed to all aspects of the
-project: 
-
-*  Rendered documentation
-*  Code repository (Github, Gitlab etc)
-*  Packagist
-*  TYPO3 Extension Repository (TER)
-*  Where to report issues
-
-Therefore, set up a convenient
+project: the rendered documentation, the code repository, and the Packagist and
+TYPO3 Extension Repository (TER) store pages from which the extension
+or package can be downloaded and installed. Therefore, set up a convenient
 navigation from one aspect to another by using native configuration settings.
 
 .. uml::
@@ -62,6 +56,9 @@ navigation from one aspect to another by using native configuration settings.
 Project aspects
 ===============
 
+Create the round trip by cross-referencing between all aspects of a project as
+follows.
+
 
 .. _user-round-trip-documentation-aspect:
 
@@ -86,14 +83,15 @@ for example for the *News System* extension:
    project_issues       = https://github.com/georgringer/news/issues
 
 and find the links to the other aspects displayed in the footer of the rendered
-documentation (see `News extension <https://docs.typo3.org/p/georgringer/news/main/en-us/>`__).
+documentation (see `News System example <https://docs.typo3.org/p/georgringer/news/main/en-us/>`__).
 
 For a Composer package, replace the TER URL with the Packagist URL. For a
 standalone manual, replace the TER URL with the documentation URL.
 
 The Packagist URL is linked indirectly from the TER page and is therefore not
-specified in this configuration file. The issues URL is considered here because
-it is closely related to the VCS repository aspect.
+specified in this configuration file. The issues URL is specified, but not
+considered part of the round trip, as it usually does not provide a way to link
+to other aspects.
 
 
 .. _user-round-trip-vcs-repository-aspect:
@@ -165,8 +163,8 @@ Packagist page (see `Address List example <https://packagist.org/packages/friend
 
 For a Composer package, replace the TER URL with the Packagist URL.
 
-The issues URL is considered here because it is closely related to the VCS
-repository aspect.
+The issues URL is specified, but not considered part of the round trip, as it
+usually does not provide a way to link to other aspects.
 
 
 .. _user-round-trip-ter-aspect:
@@ -194,14 +192,18 @@ and find the links to the other aspects presented in the right column of the TER
 page (see `Static File Cache example <https://extensions.typo3.org/extension/staticfilecache>`__).
 
 The documentation URL is automatically resolved when the documentation is
-published on docs.typo3.org. The issues URL is considered here because it is
-closely related to the VCS repository aspect.
+published on docs.typo3.org. The issues URL is specified, but not considered
+part of the round trip, as it usually does not provide a way to link to other
+aspects.
 
 
 .. _user-round-trip-project-types:
 
 Project types
 =============
+
+It depends on your project type whether all aspects can be configured or only a
+subset.
 
 
 .. _user-round-trip-typo3-extension-type:
@@ -239,7 +241,7 @@ TYPO3 extension
    hide << inactive >> stereotype
 
 Guide the user to all four aspects of the TYPO3 extension, which is usually
-hosted on both TER and Packagist, by configuring:
+distributed on both TER and Packagist, by configuring:
 
 #. :ref:`user-round-trip-documentation-aspect`
 #. :ref:`user-round-trip-vcs-repository-aspect`
@@ -285,7 +287,7 @@ Composer package
 
    hide << inactive >> stereotype
 
-A Composer package that is not a TYPO3 extension is usually hosted only on
+A Composer package that is not a TYPO3 extension is usually distributed only on
 Packagist. Therefore, guide the user to three aspects of the package by
 configuring:
 
@@ -333,7 +335,7 @@ Standalone manual
    hide << inactive >> stereotype
 
 A standalone manual, i.e. a tutorial, guide or reference, is usually not
-hosted in a store. Therefore, guide the user to two aspects of the manual by
+provided in a store. Therefore, guide the user to two aspects of the manual by
 configuring:
 
 #. :ref:`user-round-trip-documentation-aspect`

--- a/Documentation/UserRoundTrip.rst
+++ b/Documentation/UserRoundTrip.rst
@@ -6,12 +6,14 @@
 User's round trip
 =================
 
-Once the user is interested in a TYPO3 extension, a Composer package or a
-standalone manual, they should be quickly directed to all aspects of the
-project: the rendered documentation, the code repository, and the Packagist and
-TYPO3 Extension Repository (TER) store pages from which the extension
-or package can be downloaded and installed. Therefore, set up a convenient
-navigation from one aspect to another by using native configuration settings.
+When a user wants to find out more about a Composer package or a
+standalone manual, they should be provided with information about every aspect of the
+project including its rendered documentation, code repository and the Packagist and
+TYPO3 Extension Repository (TER) pages.
+
+It is recommended that you set up a navigation structure that signposts every part of
+your project so that users can quickly install, learn and potentially contribute
+to your project. This can be achieved by using the native configuration settings.
 
 .. uml::
 

--- a/Documentation/UserRoundTrip.rst
+++ b/Documentation/UserRoundTrip.rst
@@ -86,7 +86,7 @@ for example for the *News System* extension:
    project_issues       = https://github.com/georgringer/news/issues
 
 and find the links to the other aspects displayed in the footer of the rendered
-documentation (see `News System example <https://docs.typo3.org/p/georgringer/news/main/en-us/>`__).
+documentation (see `News extension <https://docs.typo3.org/p/georgringer/news/main/en-us/>`__).
 
 For a Composer package, replace the TER URL with the Packagist URL. For a
 standalone manual, replace the TER URL with the documentation URL.


### PR DESCRIPTION
After having created and published the project's documentation, a navigation should be set up that guides the project user across documentation, code repository and Packagist and TER pages.

Fixes: #280 