### PR TITLE
Change default rst indentation to 4 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
-indent_size = 3
+indent_size = 4
 max_line_length = 80
 
 # MD-Files

--- a/Documentation/GeneralConventions/CodingGuidelines.rst
+++ b/Documentation/GeneralConventions/CodingGuidelines.rst
@@ -36,13 +36,13 @@ Whitespace and indentation
 
 *  remove white space from the end of lines (= no trailing tabs or spaces)
 *  don't use tabs
-*  one indentation level consists of **three spaces**
-*  code examples use three spaces as indentation level as well
+*  one indentation level consists of **four spaces**
+*  code examples use four spaces as indentation level as well
 
 .. note::
 
    Currently, the documentation is not always indented consistently.
-   In some manuals, an indentation level of 4 spaces was used instead.
+   In some manuals, an indentation level of 3 spaces was used instead.
    We currently recommend to use what has been used on the page you
    are currently editing.
 
@@ -57,7 +57,7 @@ Example:
       :class: with-shadow
 
 
-*  lines 2-4 must be indented one level (3 spaces)
+*  lines 2-4 must be indented one level (4 spaces)
 
 
 .. index:: reST; Line length
@@ -123,7 +123,7 @@ This sample .editorconfig will instruct your editor / IDE to:
 
 *  use utf8 as encoding (line 7)
 *  use spaces instead of tabs (line 11)
-*  use 3 spaces for indenting (line 12)
+*  use 4 spaces for indenting (line 12)
 *  remove trailing whitespace (line 10)
 
 

--- a/Documentation/WritingDocsOfficial/GithubMethod.rst
+++ b/Documentation/WritingDocsOfficial/GithubMethod.rst
@@ -43,7 +43,7 @@ Workflow #1: "Edit on GitHub"
 5. Make your changes:
 
    You will be presented with a window where you can make your changes.
-   The *"Indent mode: Spaces"* and *"Indent size: 3"*
+   The *"Indent mode: Spaces"* and *"Indent size: 4"*
    values should already be set - do not alter these.
 
    .. image:: ../images/github-edit-window.png

--- a/Documentation/WritingReST/BasicRestSyntax.rst
+++ b/Documentation/WritingReST/BasicRestSyntax.rst
@@ -49,12 +49,12 @@ In reST, the indentation of a block of lines is often important. The exact numbe
 which are used to indent a block of text, does not matter. But what does matter, is that all lines
 of the block are indented with exactly the same number of spaces.
 
-We use the convention of 3 spaces per indenting level (see :ref:`cgl-indenting`).
+We use the convention of 4 spaces per indenting level (see :ref:`cgl-indenting`).
 
 Let's look at an example:
 
 The following directive inserts an image in the rendered page. All lines beginning with line
-two must be indented to the same leve. The convention is to use three spaces for one
+two must be indented to the same leve. The convention is to use 4 spaces for one
 level of indentation.
 
 .. code-block:: rest

--- a/Documentation/WritingReST/CheatSheet.rst
+++ b/Documentation/WritingReST/CheatSheet.rst
@@ -227,10 +227,10 @@ For further dummy domains use subdomains of the domains listed above such as
 To create a bullet list:
 
 *  add a blank line before and after the list
-*  indent the list item text by 3 spaces - including the item sign
+*  indent the list item text by 4 spaces - including the item sign
 *  to create a nested list:
 
-   *  indent the items by 3 spaces (left-align with parent item text)
+   *  indent the items by 4 spaces (left-align with parent item text)
    *  apply rules of parent list (blank lines, item text indentation, ..)
 
 More text.
@@ -242,10 +242,10 @@ Source:
    To create a bullet list:
 
    *  add a blank line before and after the list
-   *  indent the list item text by 3 spaces - including the item sign
+   *  indent the list item text by 4 spaces - including the item sign
    *  to create a nested list:
 
-      *  indent the items by 3 spaces (left-align with parent item text)
+      *  indent the items by 4 spaces (left-align with parent item text)
       *  apply rules of parent list (blank lines, item text indentation, ..)
 
    More text.
@@ -261,10 +261,10 @@ Source:
 To create a numbered list:
 
 #. add a blank line before and after the list
-#. indent the list item text by 3 spaces - including the item sign
+#. indent the list item text by 4 spaces - including the item sign
 #. to create a nested list:
 
-   #. indent the items by 3 spaces (left-align with parent item text)
+   #. indent the items by 4 spaces (left-align with parent item text)
    #. apply rules of parent list (blank lines, item text indentation, ..)
 
 More text.
@@ -276,10 +276,10 @@ Source:
    To create a numbered list:
 
    #. add a blank line before and after the list
-   #. indent the list item text by 3 spaces - including the item sign
+   #. indent the list item text by 4 spaces - including the item sign
    #. to create a nested list:
 
-      #. indent the items by 3 spaces (left-align with parent item text)
+      #. indent the items by 4 spaces (left-align with parent item text)
       #. apply rules of parent list (blank lines, item text indentation, ..)
 
    More text.
@@ -322,7 +322,7 @@ This uses the **directive** "code-block" (line 1)
 .. important::
 
    Make sure to indent correctly. The lines of the code-block (line 3+)
-   must be indented (3 spaces).
+   must be indented (4 spaces).
 
 
 Literal Block (`::`)

--- a/Documentation/WritingReST/Codeblocks.rst
+++ b/Documentation/WritingReST/Codeblocks.rst
@@ -16,8 +16,7 @@ Quick Reference
 ===============
 
 A code block consists of a `code-block` directive and the actual code indented
-by three spaces, the standard indentation for ReStructured Text. The TYPO3 source uses four
-spaces instead for consistency with other code bases.
+by four spaces for consistency with other code bases.
 
 A code block can have one or more options. To make orientation in code examples easier
 try to always add a `:caption:` with the path and name of the file where the example should go:

--- a/Documentation/WritingReST/CommonPitfalls/Indents.rst
+++ b/Documentation/WritingReST/CommonPitfalls/Indents.rst
@@ -10,7 +10,7 @@ Problems with indents
 Common mistake #1: Incorrect indents
 ====================================
 
-Always indent correctly (3 spaces per level)
+Always indent correctly (4 spaces per level)
 
 
 Correct syntax

--- a/Documentation/WritingReST/Images.rst
+++ b/Documentation/WritingReST/Images.rst
@@ -29,7 +29,7 @@ Use `.. figure::` if you want to add a caption to your image.
 You can use the same parameters in figure that are defined for image.
 
 The
-additional parameters must be indented one level (add 3 spaces to indent).
+additional parameters must be indented one level (add 4 spaces to indent).
 
 Recommended parameters for images:
 

--- a/Documentation/WritingReST/Lists.rst
+++ b/Documentation/WritingReST/Lists.rst
@@ -11,14 +11,14 @@ This section contains information on bullet lists and numbered lists.
 A text block which begins with a "\*", "+", "-", "•", "‣", or "⁃",
 followed by whitespace, is a bullet list item.
 
-*  Each item of a list should start with a `*` or `-` and 2 spaces after it
+*  Each item of a list should start with a `*` or `-` and 3 spaces after it
 *  Lists should have an empty line before and after
 *  Sublists should also have an empty line before and after
-*  Indent sublists with 3 spaces
+*  Indent sublists with 4 spaces
 
 Bullet lists:
 
-*  Each item of a list should start with a `*` or `-` and 2 spaces after it
+*  Each item of a list should start with a `*` or `-` and 3 spaces after it
 
 Numbered lists:
 
@@ -101,7 +101,7 @@ Example 3: List with sublist and whitespace error
 
 .. important::
 
-   Each asterix `*` has to be followed by two spaces. 
+   Each asterix `*` has to be followed by three spaces.
    If you only use one the sublist is interpreted like
    a citation.
 
@@ -122,7 +122,7 @@ Example 3: List with sublist and whitespace error
 
    * subitem 3.1
    * subitem 3.2
-   
+
 * item 4
 
 


### PR DESCRIPTION
To prevent separate text changes from syntax changes the examples have not been updated yet. will do that in a follow up

refs https://github.com/TYPO3-Documentation/T3DocTeam/issues/194