### PR TITLE
Change editorconfig to use 4 spaces

### DIFF
--- a/Documentation/GeneralConventions/CodingGuidelines.rst
+++ b/Documentation/GeneralConventions/CodingGuidelines.rst
@@ -105,7 +105,7 @@ Sample contents of :file:`.editorconfig`
    insert_final_newline = true
    trim_trailing_whitespace = true
    indent_style = space
-   indent_size = 3
+   indent_size = 4
    max_line_length = 80
 
    # MD-Files


### PR DESCRIPTION
refs https://github.com/TYPO3-Documentation/T3DocTeam/issues/194