### PR TITLE
Removed all remains of litteral blocks (::) and highlight directive

### DIFF
--- a/Documentation/Appendix/ExampleTocTree/Index.rst
+++ b/Documentation/Appendix/ExampleTocTree/Index.rst
@@ -1,5 +1,4 @@
 .. include:: /Includes.rst.txt
-.. highlight:: rst
 .. index:: pair: Examples; Toctree
 .. _example-toctree:
 

--- a/Documentation/Appendix/ExampleTocTree/Topic1/Index.rst
+++ b/Documentation/Appendix/ExampleTocTree/Topic1/Index.rst
@@ -1,5 +1,4 @@
 .. include:: /Includes.rst.txt
-.. highlight:: rst
 
 .. _example-toctree-topic1:
 

--- a/Documentation/Appendix/ExampleTocTree/Topic1/Subtopic1.rst
+++ b/Documentation/Appendix/ExampleTocTree/Topic1/Subtopic1.rst
@@ -1,5 +1,4 @@
 .. include:: /Includes.rst.txt
-.. highlight:: rst
 
 .. _example-toctree-subtopic1:
 

--- a/Documentation/Appendix/ExampleTocTree/Topic1/Subtopic2.rst
+++ b/Documentation/Appendix/ExampleTocTree/Topic1/Subtopic2.rst
@@ -1,5 +1,4 @@
 .. include:: /Includes.rst.txt
-.. highlight:: rst
 
 .. _example-toctree-subtopic2:
 

--- a/Documentation/GeneralConventions/CommitMessages.rst
+++ b/Documentation/GeneralConventions/CommitMessages.rst
@@ -1,5 +1,4 @@
 .. include:: /Includes.rst.txt
-.. highlight:: rst
 .. index:: Git; Commit messages
 .. _general-conventions-commit-messages:
 

--- a/Documentation/GeneralConventions/ContentStyleGuide.rst
+++ b/Documentation/GeneralConventions/ContentStyleGuide.rst
@@ -1,5 +1,4 @@
 .. include:: /Includes.rst.txt
-.. highlight:: rst
 .. index:: Spelling
 .. _content-styleguide:
 .. _spelling:

--- a/Documentation/GeneralConventions/Format.rst
+++ b/Documentation/GeneralConventions/Format.rst
@@ -1,5 +1,4 @@
 .. include:: /Includes.rst.txt
-.. highlight:: rst
 .. index:: Documentation; Formats
 .. _supported-formats:
 

--- a/Documentation/WritingReST/CheatSheet.rst
+++ b/Documentation/WritingReST/CheatSheet.rst
@@ -1,21 +1,4 @@
-..  This is a comment. It starts with 2 dots and a space
-
-..  -----------------------------------------------------------
-    include directive: Here, it includes the file
-    Includes.rst.txt. All files in the documentation project should
-    do this. Use correct path!
-    -----------------------------------------------------------
-
 ..  include:: /Includes.rst.txt
-
-..  ------------------------------------------------------------------
-    highlight directive: sets the default language for code-blocks.
-    Usually, default is set to PHP in Includes.rst.txt. Here, we set it to
-    rst (for reStructuredText).
-    ------------------------------------------------------------------
-
-..  highlight:: rst
-
 
 ..  ------------------------------------------------------------------------
     header label:  You can use this to create
@@ -65,9 +48,11 @@ styles in any order you want. These are our conventions for TYPO3 documentation.
         """"""""""""""
 
 *   line 1-3: This is the doc title. Every .rst file should have one.
-*   line 7: header label. This can be used for cross-referencing to this section::
+*   line 7: header label. This can be used for cross-referencing to this section:
 
-     :ref:`header1`
+    ..  code-block:: rest
+
+        :ref:`header1`
 
 *   9-10: Header level 1
 *   etc.
@@ -89,7 +74,9 @@ styles in any order you want. These are our conventions for TYPO3 documentation.
 External links
 --------------
 
-method 1::
+method 1:
+
+..  code-block:: rest
 
     `anchor text <URL>`__
 
@@ -97,7 +84,9 @@ method 1::
 
 (with one or two underscores at the end, if in doubt, use two)
 
-method 2: "External Hyperlink Targets"::
+method 2: "External Hyperlink Targets":
+
+..  code-block:: rest
 
     Check out more information on t3o_
 
@@ -116,18 +105,24 @@ Cross references
 
 When linking within docs.typo3.org, you should use this method of cross-referencing.
 
-Use it to link to a section in this manual::
+Use it to link to a section in this manual:
+
+..  code-block:: rest
 
     :ref:`intersphinx`
 
-A section with the label **intersphinx** must exist! It is placed before the header::
+A section with the label **intersphinx** must exist! It is placed before the header:
+
+..  code-block:: rest
 
     ..  _intersphinx:
 
     Intersphinx
     ===========
 
-Or, when cross-referencing to other manuals::
+Or, when cross-referencing to other manuals:
+
+..  code-block:: rest
 
     :ref:`shortcut:label`
 
@@ -135,12 +130,14 @@ Or, when cross-referencing to other manuals::
 
 
 When you are linking to another manual, make sure the
-shortcut (here: "h2document") is included in :ref:`settings-cfg`::
+shortcut (here: "h2document") is included in :ref:`settings-cfg`:
 
-        [intersphinx_mapping]
+..  code-block:: none
 
-        h2document         = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/Index.html
-        ...
+    [intersphinx_mapping]
+
+    h2document         = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/Index.html
+    ...
 
 We use the same conventions for naming the shortcuts in :file:`Settings.cfg`,
 see :ref:`settings-cfg`. Not used manuals are commented out.
@@ -324,27 +321,6 @@ This uses the **directive** "code-block" (line 1)
     Make sure to indent correctly. The lines of the code-block (line 3+)
     must be indented (4 spaces).
 
-
-Literal Block (`::`)
---------------------
-
-Or, use the literal block markup `::` if PHP is already set as default
-with `highlight` directive and you want to combine a text with a colon,
-followed by the code block.
-
-**How it looks:**
-
-Assign the variable a::
-
-    $a = 'hello';
-
-Source::
-
-    Assign the variable a::
-
-        $a = 'hello';
-
-
 Placeholders
 ------------
 
@@ -492,7 +468,9 @@ Source:
 
     1.  Embed an image
 
-        Source::
+        Source:
+
+        ..  code-block:: rest
 
             ..  image: some_image.png
                 :class: with-shadow
@@ -511,7 +489,9 @@ With Big Numbers XXL
 
 1.  Embed an image
 
-    Source::
+    Source:
+
+    ..  code-block:: rest
 
         /Images/a4.jpg
             :class: with-shadow
@@ -528,7 +508,9 @@ Source:
 
     1.  Embed an image
 
-        Source::
+        Source:
+
+        ..  code-block:: rest
 
             ..  image: some_image.png
                 :class: with-shadow

--- a/Documentation/WritingReST/CommonPitfalls/Headers.rst
+++ b/Documentation/WritingReST/CommonPitfalls/Headers.rst
@@ -21,7 +21,7 @@ throughout the docs is to to keep it the same length.
 Correct syntax
 ==============
 
-::
+..  code-block:: rest
 
    ================
    This Is a Header
@@ -39,7 +39,7 @@ Wrong syntax
 ============
 
 
-::
+..  code-block:: rest
 
    Another Header
    ------------

--- a/Documentation/WritingReST/CommonPitfalls/Hyperlinks.rst
+++ b/Documentation/WritingReST/CommonPitfalls/Hyperlinks.rst
@@ -14,14 +14,14 @@ at the bottom on this page.
 Correct syntax
 ==============
 
-::
+..  code-block:: rest
 
    `anchor text <url>`__
 
 
 Example:
 
-::
+..  code-block:: rest
 
    `T3O <https://typo3.org>`__
 
@@ -48,7 +48,7 @@ opening `<`.
 Wrong syntax
 ------------
 
-::
+..  code-block:: rest
 
    `T3O<https://typo3.org>`__
 
@@ -68,7 +68,7 @@ Missing `_` or `__` at the end:
 Wrong Syntax
 ------------
 
-::
+..  code-block:: rest
 
    `T3O <https://typo3.org>`
 

--- a/Documentation/WritingReST/CommonPitfalls/Indents.rst
+++ b/Documentation/WritingReST/CommonPitfalls/Indents.rst
@@ -16,7 +16,7 @@ Always indent correctly (4 spaces per level)
 Correct syntax
 --------------
 
-::
+..  code-block:: rest
 
    .. image:: /Images/a4.jpg
       :width: 100px
@@ -35,7 +35,7 @@ Incorrect syntax
 Here, `:width:` is indented with only 2 spaces. The image will not be
 rendered at all!
 
-::
+..  code-block:: rest
 
    .. image:: /Images/a4.jpg
       :width: 100px

--- a/Documentation/WritingReST/CommonPitfalls/InlineStyle.rst
+++ b/Documentation/WritingReST/CommonPitfalls/InlineStyle.rst
@@ -15,7 +15,7 @@ the markup and the styled text.
 Correct syntax
 --------------
 
-::
+..  code-block:: rest
 
    This is normal text. **This is bold text.**
 
@@ -28,7 +28,7 @@ This is normal text. **This is bold text.**
 Wrong syntax
 ------------
 
-::
+..  code-block:: rest
 
    This is normal text. ** This is bold text.**
 

--- a/Documentation/WritingReST/CommonPitfalls/Lists.rst
+++ b/Documentation/WritingReST/CommonPitfalls/Lists.rst
@@ -20,7 +20,7 @@ Correct syntax
 Example 1: Bullet list
 ~~~~~~~~~~~~~~~~~~~~~~
 
-::
+..  code-block:: rest
 
    this is some text
 
@@ -42,7 +42,7 @@ more text
 Example 2: List with sublist
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+..  code-block:: rest
 
    this is some text
 
@@ -69,7 +69,7 @@ this is more text
 Wrong syntax
 ------------
 
-::
+..  code-block:: rest
 
    this is some text
    *  this is a list item

--- a/Documentation/WritingReST/Reference/Code/Codeblocks.rst
+++ b/Documentation/WritingReST/Reference/Code/Codeblocks.rst
@@ -133,7 +133,6 @@ Examples
 A simple code block with syntax highlighting
 --------------------------------------------
 
-
 ..  tabs::
 
     ..  group-tab:: Source (rst)

--- a/Documentation/WritingReST/Reference/Content/BoldItalic.rst
+++ b/Documentation/WritingReST/Reference/Content/BoldItalic.rst
@@ -13,7 +13,7 @@ Bold, Italic etc.
 Bold
 ====
 
-::
+..  code-block:: rest
 
     This is normal text. **This is bold text**
 
@@ -27,7 +27,7 @@ This is normal text. **This is bold text**
 Italic
 ======
 
-::
+..  code-block:: rest
 
     This is normal text. *This is italic text.*
 

--- a/Documentation/WritingReST/Reference/Content/Links.rst
+++ b/Documentation/WritingReST/Reference/Content/Links.rst
@@ -111,7 +111,7 @@ External link as anonymous URL
 Syntax
 ~~~~~~
 
-::
+..  code-block:: rest
 
     `Anchor text <URL>`__
 
@@ -120,7 +120,7 @@ Syntax
 Example
 ~~~~~~~
 
-::
+..  code-block:: rest
 
     `Sphinx hyperlinks <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#hyperlinks>`__
 
@@ -143,7 +143,7 @@ Syntax
 Same as :ref:`anonymous URL <external-links-anonymous>`, but with one
 underscore instead of 2.
 
-::
+..  code-block:: rest
 
     `Anchor text <URL>`_
 
@@ -395,7 +395,8 @@ For example:
     The class :php:`MailMessage` can be used to generate and send a mail without
     using Fluid:
 
-    ::
+
+    ..  code-block:: rest
 
         $mail = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Mail\MailMessage::class);
         $mail

--- a/Documentation/WritingReST/Reference/Content/SpecialCharacters.rst
+++ b/Documentation/WritingReST/Reference/Content/SpecialCharacters.rst
@@ -112,7 +112,8 @@ Using U+2420 symbol for space
 
 Code
 ----
-::
+
+..  code-block:: rest
 
     *   ``:literal:`␠abc``` → :literal:`␠abc`
     *   ```␠abc``` → `␠abc`

--- a/Documentation/WritingReST/Reference/Graphics/Index.rst
+++ b/Documentation/WritingReST/Reference/Graphics/Index.rst
@@ -1,5 +1,4 @@
 ..  include:: /Includes.rst.txt
-..  highlight:: rst
 ..  _rest-menu:
 ..  _rest-page-structure:
 


### PR DESCRIPTION
We always use explicit code-blocks