### PR TITLE
Update types-of-documentation link

### DIFF
--- a/Documentation/WritingContent/Index.rst
+++ b/Documentation/WritingContent/Index.rst
@@ -7,8 +7,9 @@ How to write good content
 =========================
 
 
-*  Daniele Procida: `"What nobody tells you about documentation <https://www.divio.com/blog/documentation/>`__
-   (May 19, 2017) - A very good blogpost about different kind of manuals.
+*  Divio: `"The documentation system" <https://documentation.divio.com/>`__, based on
+   Daniele Procida's 2017 blog post, "What nobody tells you about documentation".
+   It establishes four distinct categories of documentation content.
 
 .. figure:: /Images/content-types.png
    :class: with-shadow


### PR DESCRIPTION
The original blog post is now a 404, but most of its content was incorporated into Divio's own meta-documentation.