### PR TITLE
Replace links to start page (:doc: => :ref:)

### DIFF
--- a/Documentation/BasicPrinciples.rst
+++ b/Documentation/BasicPrinciples.rst
@@ -32,7 +32,7 @@ What is the TYPO3 documentation?
 TYPO3 documentation may be one of the following:
 
 *  It can be one of the `official manuals <https://docs.typo3.org/>`__
-   like :doc:`t3coreapi:Index`.
+   like :ref:`t3coreapi:start`.
 *  It can be the documentation of a
    `system extension <https://docs.typo3.org/typo3cms/SystemExtensions/Index.html>`__.
 *  It can be the documentation of a
@@ -100,7 +100,7 @@ Manual
 A "manual" in the context of TYPO3 documentation is being used to talk about
 one unit of documentation, which usually has it's own git repository (or is
 included in the git repository of an extension) and consists of one :file:`Documentation`
-folder. A "manual" can be a tutorial, such as the :doc:`t3start:Index`, a guide,
+folder. A "manual" can be a tutorial, such as the :ref:`t3start:start`, a guide,
 an extension manual or something else.
 
 

--- a/Documentation/GeneralConventions/HowToUpdateDocs.rst
+++ b/Documentation/GeneralConventions/HowToUpdateDocs.rst
@@ -10,8 +10,8 @@
 Update documentation for new releases
 =====================================
 
-Once a new TYPO3 release comes out, the main documentation (for example :doc:`t3coreapi:Index`,
-:doc:`t3tca:Index` etc.) must be updated.
+Once a new TYPO3 release comes out, the main documentation (for example :ref:`t3coreapi:start`,
+:ref:`t3tca:start` etc.) must be updated.
 
 Here, we describe some best practices for updating the official documentation
 for a new TYPO3 release. We stick to the core conventions as much as possible because that
@@ -162,7 +162,7 @@ applied, you might use::
    :Status:
       needs review (All changelogs <= TYPO3 9.5.9 have been applied)
 
-See :doc:`t3start:Index`.
+See :ref:`t3start:start`.
 
 
 Work in progress

--- a/Documentation/GeneralConventions/ReviewInformation.rst
+++ b/Documentation/GeneralConventions/ReviewInformation.rst
@@ -98,7 +98,7 @@ the review information on the start page, for example
 
 Examples:
 
-*  :doc:`t3start:Index`.
+*  :ref:`t3start:start`.
 
 
 .. index::

--- a/Documentation/GitHub/Index.rst
+++ b/Documentation/GitHub/Index.rst
@@ -21,7 +21,7 @@ How to find a GitHub repository
 ===============================
 
 The source for every manual on docs.typo3.org (for example this manual :ref:`start` or
-:doc:`t3coreapi:Index`) is contained in a GitHub repository.
+:ref:`t3coreapi:start`) is contained in a GitHub repository.
 
 In the repository, you can find the source files, but also the issues and pull requests.
 

--- a/Documentation/RenderingDocs/RenderWithDockerCompose.rst
+++ b/Documentation/RenderingDocs/RenderWithDockerCompose.rst
@@ -37,7 +37,7 @@ work fine on all platforms.
    .. tip::
 
       Some of our repositories already contain
-      this, for example the :doc:`t3contribute:Index`
+      this, for example the :ref:`t3contribute:start`
       or this guide.
 
    You can create the file in the project directory.

--- a/Documentation/WritingDocForExtension/ContributeToSystemExtension.rst
+++ b/Documentation/WritingDocForExtension/ContributeToSystemExtension.rst
@@ -17,7 +17,7 @@ see :ref:`overview-of-types`.
    core (like system extension documentation and changelog), you would
    use Forge to report **issues**, using the category "Documentation":
    https://forge.typo3.org/projects/typo3cms-core/issues
-*  The :doc:`t3contribute:Index` explains the **contribution workflow** for the core.
+*  The :ref:`t3contribute:start` explains the **contribution workflow** for the core.
    For making a change to the documentation in the core, you would use the
    workflow explained in that guide (using Git and pushing to Gerrit).
 *  You can also test the change by :ref:`rendering locally <rendering-docs>`

--- a/Documentation/WritingDocsOfficial/GithubMethod.rst
+++ b/Documentation/WritingDocsOfficial/GithubMethod.rst
@@ -21,8 +21,8 @@ Workflow #1: "Edit on GitHub"
 2. Find a page that needs improving:
 
    For example, you may have found a misspelling in
-   the :doc:`t3start:Index` or you want to add some new content
-   to the :doc:`t3install:Index`.
+   the :ref:`t3start:start` or you want to add some new content
+   to the :ref:`t3install:start`.
 
 3. Edit the page on GitHub:
 

--- a/Documentation/WritingDocsOfficial/HowYouCanHelp.rst
+++ b/Documentation/WritingDocsOfficial/HowYouCanHelp.rst
@@ -114,7 +114,7 @@ You can create further cheat sheets and add them to this list.
 Replace Outdated Images
 =======================
 
-Replace outdated images, for example in the :doc:`t3tsconfig:Index`
+Replace outdated images, for example in the :ref:`t3tsconfig:start`
 reference.
 
 Look at :ref:`how-to-document-images` for information about how to
@@ -149,13 +149,13 @@ issue for it, if you cannot make the changes yourself.
 
 You can for example start with:
 
-*  :doc:`t3extbasebook:Index` : This currently needs some work in all branches. Check if the text
+*  :ref:`t3extbasebook:start` : This currently needs some work in all branches. Check if the text
    is up to date and technically correct. Also, the text needs to be shortened in some parts and
    language improvements are necessary (grammar, style). For the `main` branch, you can
    `check off this review list <https://github.com/TYPO3-Documentation/TYPO3CMS-Book-ExtbaseFluid/issues/296>`__
    once you have started reviewing. This makes it easier for other reviewers to just skip the parts
    that are already ok.
-*  :doc:`t3coreapi:Index`: The same applies as for :doc:`t3extbasebook:Index` except that
+*  :ref:`t3coreapi:start`: The same applies as for :ref:`t3extbasebook:start` except that
    "TYPO3 Explained" is generally in much better shape. Still, you can help by reviewing and
    `checking off this review list <https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/537>`__
 


### PR DESCRIPTION
We now use the start label again to link to start pages

Related: TYPO3-Documentation/T3DocTeam#198