### PR TITLE
[TASK] add information about new docker-image repository

### DIFF
--- a/Documentation/RenderingDocs/Quickstart.rst
+++ b/Documentation/RenderingDocs/Quickstart.rst
@@ -37,7 +37,7 @@ Commands to render the documentation
 
 #. Preparations
 
-   The docker image is not listed on dockerhub (hub.docker.com) anymore, therefor some perparations 
+   The docker image is not listed on dockerhub (hub.docker.com) anymore, therefore some preparations 
    need to be done once
    
    .. code-block:: bash

--- a/Documentation/RenderingDocs/Quickstart.rst
+++ b/Documentation/RenderingDocs/Quickstart.rst
@@ -38,7 +38,7 @@ Commands to render the documentation
 #. Preparations
 
    The docker image is not listed on Docker Hub (hub.docker.com) anymore, therefore some preparations 
-   need to be done once
+   need to be done once:
    
    .. code-block:: bash
    

--- a/Documentation/RenderingDocs/Quickstart.rst
+++ b/Documentation/RenderingDocs/Quickstart.rst
@@ -35,11 +35,20 @@ Commands to render the documentation
 
 .. rst-class:: bignums-xxl
 
+#. Preparations
+
+   The docker image is not listed on dockerhub (hub.docker.com) anymore, therefor some perparations 
+   need to be done once
+   
+   .. code-block:: bash
+   
+      docker pull ghcr.io/t3docs/render-documentation:v3.0.dev30
+      docker tag ghcr.io/t3docs/render-documentation:v3.0.dev30 t3docs/render-documentation:develop
 
 #. Make dockrun_t3rd available in current terminal
 
    .. code-block:: bash
-
+      
       source <(docker run --rm t3docs/render-documentation show-shell-commands)
 
    .. tip::

--- a/Documentation/RenderingDocs/Quickstart.rst
+++ b/Documentation/RenderingDocs/Quickstart.rst
@@ -37,7 +37,7 @@ Commands to render the documentation
 
 #. Preparations
 
-   The docker image is not listed on dockerhub (hub.docker.com) anymore, therefore some preparations 
+   The docker image is not listed on Docker Hub (hub.docker.com) anymore, therefore some preparations 
    need to be done once
    
    .. code-block:: bash


### PR DESCRIPTION
The docker images are hosted on github now. Explanation on how to pull them from there are added