### PR TITLE
Fixed How to render documentation numbered list by correcting indent

### DIFF
--- a/Documentation/RenderingDocs/Index.rst
+++ b/Documentation/RenderingDocs/Index.rst
@@ -35,7 +35,7 @@ or :ref:`ask for help <get-help-on-writing-docs>`.
         The docker image is not listed on Docker Hub (hub.docker.com) anymore, therefore some preparations
         need to be done once:
 
-        .. code-block:: bash
+        ..  code-block:: bash
 
             # pull 'latest' version from GitHub container repository
             docker pull ghcr.io/t3docs/render-documentation

--- a/Documentation/RenderingDocs/Index.rst
+++ b/Documentation/RenderingDocs/Index.rst
@@ -35,17 +35,17 @@ or :ref:`ask for help <get-help-on-writing-docs>`.
         The docker image is not listed on Docker Hub (hub.docker.com) anymore, therefore some preparations
         need to be done once:
 
-       .. code-block:: bash
+        .. code-block:: bash
 
-          # pull 'latest' version from GitHub container repository
-          docker pull ghcr.io/t3docs/render-documentation
+            # pull 'latest' version from GitHub container repository
+            docker pull ghcr.io/t3docs/render-documentation
 
-          # The "real" tag is independent of the container repository,
-          # so let's just create that extra "real" and "generic" tag
-          docker tag ghcr.io/t3docs/render-documentation t3docs/render-documentation
+            # The "real" tag is independent of the container repository,
+            # so let's just create that extra "real" and "generic" tag
+            docker tag ghcr.io/t3docs/render-documentation t3docs/render-documentation
 
-          # verify it worked
-          docker run --rm t3docs/render-documentation --version
+            # verify it worked
+            docker run --rm t3docs/render-documentation --version
 
     #.  Make dockrun_t3rd available in current terminal
 


### PR DESCRIPTION
[How to render documentation](https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/RenderingDocs/Index.html) has a broken list. 
After the second step, the code block is shown as quote block and the next step starts at number one again, but should be number three.

This was solved by fixing the indent of the code block, which was previously three spaces instead of four.