### PR TITLE
[TASK] Remove root configuration from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,9 +3,6 @@
 # Use as master:
 #   https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument/blob/main/.editorconfig
 
-# top-most EditorConfig file
-root = false
-
 [{*.rst,*.rst.txt}]
 charset = utf-8
 end_of_line = lf


### PR DESCRIPTION
PhpStorm complains about this with:
"Only 'root=true' is allowed as a top-level declaration"

This way, now PhpStorm applies the editorconfig configuration to the IDE correctly.