### PR TITLE
[BUGFIX] Avoid warning of unavailable text role "shell"

### DIFF
--- a/Documentation/Maintainers/BackportChanges.rst
+++ b/Documentation/Maintainers/BackportChanges.rst
@@ -119,7 +119,7 @@ additional authors is automatically added to the commit.
 How to backport manually?
 =========================
 
-If you cherry-pick a commit locally, you can (optionally) use :shell:`-x` to
+If you cherry-pick a commit locally, you can (optionally) use :bash:`-x` to
 automatically insert information that this is a cherry-pick and
 the original commit ID.
 


### PR DESCRIPTION
This solves the following warning on rendering:

    ./Documentation/Maintainers/BackportChanges.rst:122: ERROR: Unknown interpreted text role "shell".