### PR TITLE
use correct article for the word attention

### DIFF
--- a/Documentation/WritingReST/Reference/Content/Admonitions.rst
+++ b/Documentation/WritingReST/Reference/Content/Admonitions.rst
@@ -83,10 +83,10 @@ Attention
 ..  code-block:: rst
 
     ..  attention::
-        A attention
+        An attention
 
 ..  attention::
-    A attention
+    An attention
 
 
 More Information


### PR DESCRIPTION
For the word _attention_, the article "an" is used, instead of "a", because _attention_ starts with a vowel.