### PR TITLE
[TASK] Add link to render-guides list of default inventories

### DIFF
--- a/Documentation/GeneralConventions/GuidesXml.rst
+++ b/Documentation/GeneralConventions/GuidesXml.rst
@@ -220,6 +220,9 @@ Interlink mapping
 
 .. todo: describe interlink mapping more detailed
 
+A list of globally available Interlink (formerly "Intersphinx") repositories
+can be found in :ref:`Available default inventories <t3renderguides:available-default-inventories>`
+
 It is possible, though rarely needed to define custom interlink mappings:
 
 For example:


### PR DESCRIPTION
Follow-up to https://github.com/TYPO3-Documentation/render-guides/pull/498

This adds the link to the list of interlink inventories available by default.