### PR TITLE
[BUGFIX] Resolve duplicate link anchors

### DIFF
--- a/Documentation/WritingReST/Reference/Code/Index.rst
+++ b/Documentation/WritingReST/Reference/Code/Index.rst
@@ -1,7 +1,6 @@
 ..  include:: /Includes.rst.txt
 ..  highlight:: rst
-..  _rest-menu:
-..  _rest-page-structure:
+..  _rest-code:
 
 ==============================
 Code blocks and code structure

--- a/Documentation/WritingReST/Reference/Graphics/Index.rst
+++ b/Documentation/WritingReST/Reference/Graphics/Index.rst
@@ -1,6 +1,5 @@
 ..  include:: /Includes.rst.txt
-..  _rest-menu:
-..  _rest-page-structure:
+..  _rest-images-diagrams:
 
 ===========================
 Graphs, images and diagrams


### PR DESCRIPTION
They cause warnings since the newest version of the render-guides