### PR TITLE
[TASK] Add reference to typo3-documentation-rendersync project

### DIFF
--- a/Documentation/Migration/Index.rst
+++ b/Documentation/Migration/Index.rst
@@ -340,6 +340,7 @@ https://github.com/TYPO3-Documentation/render-guides/blob/main/Makefile
 A small example :file:`Makefile`:
 
 ..  literalinclude:: /CodeSnippets/_Makefile
+    :language: plaintext
     :caption: Makefile
 
 ..  hint::

--- a/Documentation/RenderingDocs/Index.rst
+++ b/Documentation/RenderingDocs/Index.rst
@@ -68,6 +68,8 @@ Make sure that `Docker <https://www.docker.com/>`__ is installed on your system.
             docker run --rm --pull always -v ${PWD}:/project -it ghcr.io/typo3-documentation/render-guides:latest --config=Documentation
             start "Documentation-GENERATED-temp/Index.html"
 
+..  _rendering-wysiwyg:
+
 Rendering with more WYSIWYG-feeling (automatic re-rendering)
 ------------------------------------------------------------
 

--- a/Documentation/RenderingDocs/Index.rst
+++ b/Documentation/RenderingDocs/Index.rst
@@ -68,6 +68,89 @@ Make sure that `Docker <https://www.docker.com/>`__ is installed on your system.
             docker run --rm --pull always -v ${PWD}:/project -it ghcr.io/typo3-documentation/render-guides:latest --config=Documentation
             start "Documentation-GENERATED-temp/Index.html"
 
+Rendering with more WYSIWYG-feeling (automatic re-rendering)
+------------------------------------------------------------
+
+Often, especially in the later stages of creating documentation, you
+just edit small parts of the reST files, render the outcome manually
+and happily commit your changes.
+
+However, in cases you write larger sections of text, you may want
+to get more immediate visual feedback on your changes, but do not
+want to manually trigger the rendering time and again.
+
+To make this easier, the project `garvinhicking/typo3-documentation-browsersync
+<https://github.com/garvinhicking/typo3-documentation-browsersync>`__
+has been created. This docker container solution provides an environment
+which permanently watches changes to any of the reST files and automatically
+triggers a re-rendering. The generated HTML output is then served with a
+local web server (vite-based) in which your browser automatically hot-reloads
+all changes and keeps the scroll position.
+
+This allows you to have a browser window next to your reST file editor
+to view progress.
+
+Since that whole environment is based on the official
+:ref:`TYPO3 documentation rendering container <t3renderguides:start>`
+and utilizes a docker container, it is simple to use. Also, all updates
+to the `render-guides` project are automatically merged into that
+project, so all bugfixes and new features of the PHP-based rendering always
+are in sync with this WYSIWYG-project, with a possibility of this becoming
+a regular TYPO3-documentation project (given positive feedback).
+
+The project itself has `documentation on the technical details
+<https://github.com/garvinhicking/typo3-documentation-browsersync/blob/main/README.md>`__
+but all you need is this docker/podman command:
+
+..  tabs::
+
+    ..  group-tab:: Linux
+
+        ..  code-block:: bash
+
+            docker run --rm -it --pull always \
+              -v "./Documentation:/project/Documentation" \
+              -v "./Documentation-GENERATED-temp:/project/Documentation-GENERATED-temp" \
+              -p 5173:5173 ghcr.io/garvinhicking/typo3-documentation-browsersync:latest
+            xdg-open "http://localhost:5173/Documentation-GENERATED-temp/Index.html"
+
+    .. group-tab:: MacOS
+
+        ..  code-block:: bash
+
+            docker run --rm -it --pull always \
+              -v "./Documentation:/project/Documentation" \
+              -v "./Documentation-GENERATED-temp:/project/Documentation-GENERATED-temp" \
+              -p 5173:5173 ghcr.io/garvinhicking/typo3-documentation-browsersync:latest
+            open "http://localhost:5173/Documentation-GENERATED-temp/Index.html"
+
+    ..  group-tab:: Windows
+
+        ..  code-block:: powershell
+
+            docker run --rm -it --pull always \
+              -v "./Documentation:/project/Documentation" \
+              -v "./Documentation-GENERATED-temp:/project/Documentation-GENERATED-temp" \
+              -p 5173:5173 ghcr.io/garvinhicking/typo3-documentation-browsersync:latest
+            start "http://localhost:5173/Documentation-GENERATED-temp/Index.html"
+
+The command above can also be added to your project's `Makefile` or
+you can create a bash alias like:
+
+..  code:: bash
+
+    alias render-wysiwyg="docker run --rm -it --pull always \
+                            -v './Documentation:/project/Documentation' \
+                            -v './Documentation-GENERATED-temp:/project/Documentation-GENERATED-temp' \
+                            -p 5173:5173 ghcr.io/garvinhicking/typo3-documentation-browsersync:latest'"
+
+..  note::
+
+    If anything on your host operating system already utilizes the TCP port
+    `5173` you need to adapt that command to use another free TCP port for you,
+    and adapt the port in the web-browser URL.
+
+
 Publishing extension documentation to docs.typo3.org
 ====================================================
 

--- a/Documentation/RenderingDocs/Index.rst
+++ b/Documentation/RenderingDocs/Index.rst
@@ -73,6 +73,10 @@ Make sure that `Docker <https://www.docker.com/>`__ is installed on your system.
 Rendering with more WYSIWYG-feeling (automatic re-rendering)
 ------------------------------------------------------------
 
+You want to write complex `reST` markup and directly see the
+rendered output, browser side-by-side with your editor? Then
+this section is for you!
+
 Often, especially in the later stages of creating documentation, you
 just edit small parts of the reST files, render the outcome manually
 and happily commit your changes.

--- a/Documentation/WritingReST/Reference/Code/Confval.rst
+++ b/Documentation/WritingReST/Reference/Code/Confval.rst
@@ -131,6 +131,7 @@ If you put the directive somewhere on the page it will list all confvals that
 can be found on that page:
 
 ..  confval-menu::
+    :name: confval-group-1
     :display: table
     :type:
     :default:
@@ -139,6 +140,7 @@ can be found on that page:
 ..  code-block:: rst
 
     ..  confval-menu::
+        :name: confval-group-1
         :display: table
         :type:
         :default:
@@ -150,6 +152,7 @@ its child confvals. This is useful if you have several groups of confvals on
 the same page and want to list them in separate menus:
 
 ..  confval-menu::
+    :name: confval-group-2
     :display: table
     :type:
 
@@ -167,6 +170,7 @@ the same page and want to list them in separate menus:
 ..  code-block:: rst
 
     ..  confval-menu::
+        :name: confval-group-2
         :display: table
         :type:
 
@@ -189,7 +193,7 @@ The confval-menu directive has the following options:
 `:display:`
     `table`, `list`, `tree`: Different display forms, just try them out
 `:name:`
-    Reserved by reStructuredText
+    A unique identifier for the confval menu for the "to top" button
 `:class:`
     Reserved by reStructuredText
 `:exclude-noindex:`


### PR DESCRIPTION
My "pet project" typo3-documentation-browsersync is in a state where I'd like to collect some feedback, also to see if in the end this project might be movable to the TYPO3-Documentation repository.

For that I've created a small documentation on how to use it, hopefully also a base to present it for the T3DD24 in the scope of Linas talk presenting render-guides.

(This also drive-by-fixes an issue with a missing literalainclude syntax for _Makefile that removes a warning from rendering. Another issue is still open that causes the rendering to fail with a duplicate RST header, which is beyond the scope of this PR)