### PR TITLE
[TASK] Enhance glossary by specific product names

### DIFF
--- a/Documentation/GeneralConventions/Glossary.rst
+++ b/Documentation/GeneralConventions/Glossary.rst
@@ -125,7 +125,7 @@ P
 `PHP CS Fixer`,
 `PHP_CodeSniffer`,
 `PNG`,
-`PostgreSQL`,
+`PostgreSQL`
 
 Q
 

--- a/Documentation/GeneralConventions/Glossary.rst
+++ b/Documentation/GeneralConventions/Glossary.rst
@@ -119,8 +119,13 @@ O
 P
 
 `page TSconfig`,
+`PhpStorm`,
+`PHPStan`,
+`PHPUnit`,
+`PHP CS Fixer`,
+`PHP_CodeSniffer`,
 `PNG`,
-`PostgreSQL`
+`PostgreSQL`,
 
 Q
 


### PR DESCRIPTION
TYPO3 has its own rules, so let's respect upper/lowercasing from others as well :-)

Follow-up to https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/pull/4509#discussion_r1632168380