### PR TITLE
[TASK] Add missing attribute `project_discussions`

### DIFF
--- a/Documentation/GeneralConventions/_guides-simple.xml
+++ b/Documentation/GeneralConventions/_guides-simple.xml
@@ -9,6 +9,7 @@
                project-contact="https://typo3.slack.com/archives/C03TG7QJT"
                project-repository="https://github.com/georgringer/news"
                project-issues="https://github.com/georgringer/news/issues"
+               project-discussions="https://github.com/georgringer/news/discussions"
                edit-on-github-branch="main"
                edit-on-github="georgringer/news"
                typo3-core-preferred="11.5"


### PR DESCRIPTION
Add attribute `project_discussions`, as a corresponding GitHub page exists in the context of the news extension from the example.