### PR TITLE
[BUGFIX] Remove mention of php:currentnamespace::

### DIFF
--- a/Documentation/Reference/ReStructuredText/Code/Phpdomain.rst
+++ b/Documentation/Reference/ReStructuredText/Code/Phpdomain.rst
@@ -105,12 +105,6 @@ Create a namespace once per document that becomes the link target:
 
     ..  php:namespace::  Vendor\Extension
 
-Reuse a namespace, but prevent it from becoming a link target:
-
-..  code-block:: rst
-
-    ..  php:currentnamespace:: Vendor\Extension
-
 ..  _rest-phpdomain-examples:
 
 Examples


### PR DESCRIPTION
The directive doesn't exist, as discussed in Slack: https://typo3.slack.com/archives/C028JEPJL/p1737711998088519?thread_ts=1737710334.087189&cid=C028JEPJL