### PR TITLE
[DOCS] Add hints when merge conflict arises during manual backport

### DIFF
--- a/Documentation/Maintainers/BackportChanges.rst
+++ b/Documentation/Maintainers/BackportChanges.rst
@@ -117,6 +117,12 @@ additional authors is automatically added to the commit.
 How to backport manually?
 =========================
 
+Please make sure that you are in the branch you have just pushed into.
+Preferably `main`:
+
+..  code-block:: shell
+    git checkout main
+
 Look up the commit ID with
 
 ..  code-block:: shell
@@ -145,8 +151,9 @@ This is how the commit might look like:
 
         (cherry picked from commit 609493dd8893cbac7ad78aa38a23e02d011bb0c2)
 
-If a merge conflict arises solve the merge conflict. Check the syntax in the
-modified and resulting HTML file with
+If a merge conflict arises solve the merge conflict within the Git related
+files like `rst` and `md`.
+For a visual confirmation you can now execute the building process again with:
 
 ..  code-block:: shell
 

--- a/Documentation/Maintainers/BackportChanges.rst
+++ b/Documentation/Maintainers/BackportChanges.rst
@@ -117,17 +117,22 @@ additional authors is automatically added to the commit.
 How to backport manually?
 =========================
 
+Look up the commit ID with
+
+..  code-block:: shell
+
+    git log
+
+Switch to the branch to which you would like to make a backport.
 If you cherry-pick a commit locally, you can (optionally) use :shell:`-x` to
 automatically insert information that this is a cherry-pick and
 the original commit ID.
 
-This makes the history clearer. Sometimes minor changes have
-to be done while backporting to fix merge conflicts.
+This makes the history clearer.
 
 ..  code-block:: shell
 
     git cherry-pick -x <commit-id>
-
 
 This is how the commit might look like:
 
@@ -139,3 +144,20 @@ This is how the commit might look like:
         [TASK] Subject
 
         (cherry picked from commit 609493dd8893cbac7ad78aa38a23e02d011bb0c2)
+
+If a merge conflict arises solve the merge conflict. Check the syntax in the
+modified and resulting HTML file with
+
+.. code-block:: shell
+
+    make docs
+
+If everything looks fine continue the cherry-pick with
+
+.. code-block:: shell
+
+    git cherry-pick --continue
+
+Push your changes.
+Check in the intercept to see if a new rendering has started. Once this is
+done, check the documentation to see if the backport worked as expected.

--- a/Documentation/Maintainers/BackportChanges.rst
+++ b/Documentation/Maintainers/BackportChanges.rst
@@ -148,13 +148,13 @@ This is how the commit might look like:
 If a merge conflict arises solve the merge conflict. Check the syntax in the
 modified and resulting HTML file with
 
-.. code-block:: shell
+..  code-block:: shell
 
     make docs
 
 If everything looks fine continue the cherry-pick with
 
-.. code-block:: shell
+..  code-block:: shell
 
     git cherry-pick --continue
 


### PR DESCRIPTION
I thought it might help to add some hints what has to be done in case a merge conflict arises. 