### PR TITLE
[TASK] Document Forgejo and Gitea webhook support

### DIFF
--- a/Documentation/Howto/RenderingDocs/Index.rst
+++ b/Documentation/Howto/RenderingDocs/Index.rst
@@ -67,7 +67,8 @@ called :file:`Documentation` with a :file:`Documentation/Index.rst` and
 a :file:`Documentation/guides.xml` or a :file:`README.rst` / :file:`README.md`
 in the extension's root directory.
 
-The extension has to be publicly available on GitHub or GitLab. You have to
+The extension has to be publicly available on one of the
+:ref:`supported repository hosts <webhook>`. You have to
 establish a :ref:`Webhook <webhook>` and the Documentation Team has to
 :ref:`approve <approval-intercept>` your first rendering.
 

--- a/Documentation/Howto/WritingDocForExtension/FAQ.rst
+++ b/Documentation/Howto/WritingDocForExtension/FAQ.rst
@@ -133,7 +133,8 @@ TER (https://extensions.typo3.org) are two separate, independent entities.
 
 In theory you could have the documentation in GitHub (for example)
 and the extension (code) somewhere else (or not in Git at all). You just
-need to fire the webhook from GitHub/GitLab/Bitbucket to trigger the
+need to fire the webhook from one of the
+:ref:`supported repository hosts <webhook>` to trigger the
 documentation rendering.
 
 

--- a/Documentation/Howto/WritingDocForExtension/Index.rst
+++ b/Documentation/Howto/WritingDocForExtension/Index.rst
@@ -53,7 +53,8 @@ the chapter yourself.
 Make changes and try :ref:`rendering <rendering-docs>` the new documentation.
 
 To publish your documentation to https://docs.typo3.org
-a :ref:`webhook needs to be added <webhook>` on GitHub, Bitbucket or GitLab.
+a :ref:`webhook needs to be added <webhook>` on GitHub, Bitbucket, GitLab,
+Forgejo or Gitea.
 A member of the Documentation Team has to approve your new documentation guide
 for publishing. In case the Team has questions, please follow the thread
 generated for your extension in the `TYPO3 slack organization <https://typo3.org/community/meet/chat-slack>`_

--- a/Documentation/Howto/WritingDocForExtension/Webhook.rst
+++ b/Documentation/Howto/WritingDocForExtension/Webhook.rst
@@ -15,6 +15,7 @@ and integrates with the following repository hosts:
 *   :ref:`webhook-github`
 *   :ref:`webhook-bitbucket-cloud` and Bitbucket self-hosted
 *   :ref:`GitLab Cloud <webhook-gitlab>` and :ref:`GitLab self-hosted <webhook-gitlab>`
+*   :ref:`Forgejo and Gitea <webhook-forgejo>`, including self-hosted instances
 
 ..  contents:: Table of Contents
     :local:
@@ -48,9 +49,13 @@ Foreign setups
 ==============
 
 If your repository is hosted outside the supported platforms
-(GitHub, GitLab, Bitbucket) or its structure differs from a typical TYPO3
-extension, you must create a mirror on a supported platform. Otherwise,
-automatic rendering will not be possible.
+(GitHub, GitLab, Bitbucket, Forgejo, Gitea) or its structure differs from a
+typical TYPO3 extension, you must create a mirror on a supported platform.
+Otherwise, automatic rendering will not be possible.
+
+Self-hosted instances are supported on any domain. The Documentation Team
+approves the domain of your instance once, together with the repository
+approval described above.
 
 ..  _webhook-how-webhook-works:
 
@@ -228,6 +233,49 @@ To set up a GitLab webhook:
 
     ..  figure:: /_Images/webhook/gitlab/intercept-feedback.png
         :width: 932
+
+..  index:: Webhooks; Forgejo
+..  _webhook-forgejo:
+
+Forgejo and Gitea
+=================
+
+Forgejo and Gitea are supported on any domain, so a self-hosted instance
+needs no mirror. To set up the webhook:
+
+..  rst-class:: bignums-xxl
+
+#.  Open the repository **Settings** and go to the **Webhooks** section.
+
+#.  Click **Add Webhook** and choose **Forgejo** (**Gitea** on a Gitea
+    instance).
+
+#.  Configure the webhook:
+
+    *   **Target URL**: `https://docs-hook.typo3.org`
+    *   **HTTP Method**: `POST`
+    *   **POST Content Type**: `application/json`
+    *   **Trigger On**: `Custom Events`, with **Push** selected
+
+    Leave the branch filter at its default so that tags are delivered as
+    well. Select push events only. Other events, such as branch creation
+    or deletion, are rejected by the endpoint and clutter the delivery
+    history of your webhook.
+
+    Click **Add Webhook**.
+
+#.  Test the webhook.
+
+    Push a commit that changes `README.rst`, `README.md` or a file below
+    :file:`Documentation/` to `main` or `documentation-draft`. Then visit
+    `intercept.typo3.com <https://intercept.typo3.com/admin/docs/deployments>`_
+    and check the **Recent actions** section.
+
+    ..  note::
+        The **Test Delivery** button of Forgejo sends a push event that
+        contains no changed files. The delivery is reported as successful,
+        but no documentation is rendered by it. Only a real push with
+        documentation changes triggers the rendering.
 
 ..  _webhook-testing:
 


### PR DESCRIPTION
**Draft — do not merge yet.** This documents behaviour that is not deployed. It depends on TYPO3GmbH/site-intercept#305, which adds Forgejo/Gitea support to the documentation hook. Please merge this only once that change is released, otherwise this page promises something that still fails in production. I will mark it ready for review then.

## Why

The Webhook page currently lists GitHub, Bitbucket and GitLab as the supported hosts, and the "Foreign setups" section tells everyone else to create a mirror on a supported platform. That is what a Forgejo user ran into on Slack, which led to TYPO3GmbH/site-intercept#304 and then to the implementation in TYPO3GmbH/site-intercept#305.

## What changed

- **Webhook.rst** — new "Forgejo and Gitea" setup section next to the existing ones, the host list in the intro extended, and the "Foreign setups" paragraph rewritten. It also states that self-hosted instances work on any domain, with the domain approved once together with the repository.
- **WritingDocForExtension/Index.rst**, **FAQ.rst**, **RenderingDocs/Index.rst** — three enumerations that named the hosts individually now link to the webhook page instead, so the list lives in exactly one place. The one in the rendering chapter was already incomplete before this change: it named only GitHub and GitLab and omitted Bitbucket.

## Two things worth a maintainer's opinion

**No screenshots.** Every sibling section has a figure per step under `Documentation/_Images/webhook/<host>/`; the new section is text only, because I have no Forgejo instance to capture them from. Happy to add them if someone supplies the images — the original reporter runs an instance and may be willing.

**The note about "Test Delivery".** Forgejo has no ping event; its Test Delivery button sends a synthetic push whose commit lists no changed files, so intercept accepts it and answers "no documentation changes" without rendering anything. The button therefore reports success while nothing happens, which is confusing enough to warrant the note. This is from Forgejo's source (`routers/web/repo/setting/webhook.go`), not from an assumption.

## Verification

`make test-docs` renders cleanly: 92 files, no warnings or errors. Both new cross-references resolve to real links in the rendered output. I compared the render against the unmodified branch to confirm this change adds no new unresolved references.
