### PR TITLE
[TASK] Add TYPO3 module and concept terms to glossary

### DIFF
--- a/Documentation/Advanced/Glossary.rst
+++ b/Documentation/Advanced/Glossary.rst
@@ -28,6 +28,8 @@ A
 B
 
 `backend`,
+`backend user`,
+`Backend Users` (module),
 `blog post`, `blogger`, `blogging`,
 
 
@@ -38,6 +40,7 @@ C
 `command-line something`, run a command-line spell-checker,
 `Changelog`,
 `checkbox`,
+`Classic mode`,
 `Composer`,
 `Core Team`, `TYPO3 Core Team`,
 `Core`, `TYPO3 Core`,
@@ -51,6 +54,7 @@ D
 
 `Data Processor`,
 `DBAL`,
+`DB Check` (module),
 `Docker`,
 `Docker Compose`,
 `Doctrine`,
@@ -72,6 +76,7 @@ F
 
 `FlexForm`,
 `Fluid`,
+`Fluid Styled Content`,
 `FormEngine`,
 `frontend`,
 `frontend rendering`,
@@ -136,6 +141,7 @@ Q
 
 R
 
+`Records` (module),
 `reStructuredText`, `reST`,
 `richt text editor`,
 `RTE`,
@@ -187,6 +193,43 @@ Terms
 =====
 
 How to use these terms:
+
+Backend Users
+   Written as a proper noun when referring to the TYPO3 backend module for
+   managing backend user accounts and groups, found at
+   :guilabel:`System > Backend Users`. Before the module reorganization in
+   TYPO3 v14, it was listed under "Admin Tools". Lowercase "backend user"
+   still applies when talking about the user accounts themselves, not the
+   module.
+
+Changelog
+   The collection of per-release Core documentation entries (Breaking
+   Change, Feature, Deprecation, Important) published for each TYPO3 Core
+   version. Also referenced as "Core Changelog". Linked from upgrade
+   guides across many TYPO3 documentation repositories, not just this one.
+
+Classic mode
+   A TYPO3 installation mode where the full source tree, including the
+   TYPO3 Core and all extensions, lives inside the web root. Contrast with
+   Composer mode, where dependencies are managed by Composer outside the
+   web root.
+
+DB Check
+   Written as a proper noun when referring to the TYPO3 backend module
+   (provided by :composer:`typo3/cms-lowlevel`) for checking database
+   consistency and integrity, found at :guilabel:`System > DB Check`.
+
+Fluid Styled Content
+   The name of the TYPO3 system extension
+   (:composer:`typo3/cms-fluid-styled-content`) that provides the default
+   Fluid-based rendering for content elements. Also used adjectivally, for
+   example "Fluid-Styled Content templates".
+
+Records
+   Written as a proper noun when referring to the :guilabel:`Contents >
+   Records` backend module, used to find or create records independently
+   of their page context. Lowercase "records" still applies when talking
+   about database records in general, not the module.
 
 reStructuredText
    Use `reST` as abbreviation.


### PR DESCRIPTION
Add Backend Users, DB Check, Records, Classic mode, Fluid Styled
Content, and Changelog to the spelling list and terms glossary.
These are established TYPO3 names that should keep their
capitalization in prose and not be lowercased by sentence-case
style rules.

Backend Users, DB Check, and Records are also backend module
names that collide with generic lowercase words (backend user
accounts, database records), so they're marked "(module)" in the
spelling list and the terms section spells out the distinction.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf