### PR TITLE
[TASK] Add missing anchors to reST headlines

### DIFF
--- a/Documentation/Advanced/CodingGuidelines.rst
+++ b/Documentation/Advanced/CodingGuidelines.rst
@@ -6,6 +6,8 @@
 Coding guidelines for reST files
 ================================
 
+..  _format-rest-cgl-basic-formatting-rules:
+
 Basic formatting rules
 ======================
 
@@ -13,6 +15,8 @@ Basic formatting rules
 ..  index::
     reST; Encoding
     reST; Utf-8
+
+..  _format-rest-cgl-basic-formatting-rules-encoding:
 
 Encoding
 --------
@@ -59,6 +63,8 @@ Example:
 
 
 ..  index:: reST; Line length
+
+..  _format-rest-cgl-basic-formatting-rules-line-length:
 
 Line length
 -----------
@@ -127,6 +133,8 @@ This sample .editorconfig will instruct your editor / IDE to:
 
 ..  index:: reST; Special characters
 
+..  _format-rest-cgl-basic-formatting-rules-special-characters:
+
 Special characters
 ------------------
 
@@ -193,6 +201,8 @@ file:
     reST directives; deprecated
     reST directives; versionadded
     reST directives; versionchanged
+
+..  _format-rest-cgl-add-version-hints:
 
 How to add version hints
 ========================
@@ -290,6 +300,8 @@ How it looks:
 ..  index::
     reST; Keystrokes
     reST roles; kbd
+
+..  _format-rest-cgl-refering-keystrokes:
 
 Refering to keystrokes
 ======================

--- a/Documentation/Advanced/ContentStyleGuide.rst
+++ b/Documentation/Advanced/ContentStyleGuide.rst
@@ -9,6 +9,8 @@ Spelling
 
 ..  contents::
 
+..  _content-styleguide-title-capitalization:
+
 Title capitalization
 ====================
 
@@ -22,11 +24,15 @@ more words in the title. Capitalization in the documentation is still
 inconsistent currently, so you cannot rely on existing pages to show
 the correct convention.
 
+..  _content-styleguide-spelling:
+
 Spelling
 ========
 
 Use common spelling for American English. Some specific TYPO3 terms
 have a special spelling. See :ref:`spelling-ref`
+
+..  _content-styleguide-general-information:
 
 General information
 ===================
@@ -280,6 +286,8 @@ The same goes for **Docker**, **Composer**, etc.
 
 ..  index:: Spelling; Preferred terms
 
+..  _content-styleguide-spelling-preferred-terms:
+
 Spelling & preferred terms reference
 ====================================
 
@@ -287,6 +295,8 @@ The content was moved to :ref:`spelling-ref`.
 
 
 ..  index:: Spelling; Resources
+
+..  _content-styleguide-used-resources:
 
 Used resources
 ==============

--- a/Documentation/Advanced/Format.rst
+++ b/Documentation/Advanced/Format.rst
@@ -50,6 +50,8 @@ You can consult our Markdown reference for more information.
     reST; vs. Markdown
     Markdown; vs. reST
 
+..  _supported-formats-rest-vs-markdown:
+
 reST vs. Markdown
 =================
 
@@ -100,6 +102,8 @@ readthedocs:
 *   various flavors (unless **commonmark** is used)
 *   less features
 
+
+..  _supported-formats-rest-vs-markdown-additional-information:
 
 Additional information
 ----------------------

--- a/Documentation/Advanced/Glossary.rst
+++ b/Documentation/Advanced/Glossary.rst
@@ -11,6 +11,8 @@
 Spelling, terms and glossary
 ============================
 
+..  _preferred-terms-spelling:
+
 Spelling
 ========
 
@@ -188,6 +190,8 @@ W
 `windows`, `modal windows`,
 
 
+
+..  _preferred-terms-terms:
 
 Terms
 =====

--- a/Documentation/Advanced/ReviewPolicy.rst
+++ b/Documentation/Advanced/ReviewPolicy.rst
@@ -71,6 +71,8 @@ The review process should have the **same standard** for anyone of the
 maintainer team performing the review, and every member of the team
 should feel good when **making decisions** on what and how to give feedback on.
 
+..  _review-policy-maintainers-basic-work-contributions:
+
 Basic work on contributions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -97,6 +99,8 @@ Basic work on contributions
     *   **Fix mistakes in reST markup** (indentation, wrong directives, missing headers,
         wrong or missing linebreaks, wrong or bad links/references, ...) - see
         :ref:`format-rest-cgl`.
+
+..  _review-policy-maintainers-workflow-follow-ups:
 
 Workflow and follow-ups to contributions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Documentation/Howto/Contribute/HowYouCanHelp.rst
+++ b/Documentation/Howto/Contribute/HowYouCanHelp.rst
@@ -20,6 +20,8 @@ very much appreciated.
     bothers you the most.
 
 
+..  _docs-official-how-you-can-help-make-minor-changes:
+
 Make minor changes
 ==================
 
@@ -141,12 +143,16 @@ Here are some examples:
 *   :ref:`Get started with PlantUML diagrams <PlantUML-diagrams>`
 
 
+..  _docs-official-how-you-can-help-replace-outdated-images:
+
 Replace outdated images and screenshots
 =======================================
 
 Look at :ref:`how-to-document-images` for information about how to
 embed images with reST.
 
+
+..  _docs-official-how-you-can-help-add-youtube-videos:
 
 Add YouTube videos
 ==================
@@ -188,6 +194,8 @@ an entire manual can be quite too much to do for one person).
     and you get feedback more quickly.
 
 
+..  _docs-official-how-you-can-help-teach:
+
 Teach
 =====
 
@@ -195,6 +203,8 @@ If you are already familiar with the workflow, you can help others to get
 started. Whenever you are at a `TYPO3 event`_ (sprint, barcamp, etc.), on
 `StackOverflow`_ or in a `Slack`_ channel and someone finds something missing or
 a problem in the documentation, help them make the necessary changes themselves.
+
+..  _docs-official-how-you-can-help-motivate:
 
 Motivate
 ========
@@ -216,6 +226,8 @@ Remind people, that everyone can contribute!
 Write on `Mastodon`_ (hashtag: `#TYPO3`). Additionally, you can use `#T3Docs`,
 `#T3Contribute`, and mention `@documentation@typo3.social`_.
 
+
+..  _docs-official-how-you-can-help-blog-contributions:
 
 Blog about your contributions
 =============================
@@ -266,6 +278,8 @@ Check spelling
 Check spelling for consistency. For example, compare spelling of title
 and headlines to the rules outlined in the :ref:`spelling` chapter.
 
+
+..  _docs-official-how-you-can-help-ideas:
 
 More ideas?
 ===========

--- a/Documentation/Howto/EditLocal.rst
+++ b/Documentation/Howto/EditLocal.rst
@@ -130,6 +130,8 @@ the ability to experiment and preview your changes locally before submitting the
 **Congratulations! You are now a contributor. Welcome and thank you!**
 
 
+..  _docs-contribute-git-docker-next-steps:
+
 Next steps
 ==========
 
@@ -141,6 +143,8 @@ Next steps
 
 Keeping your local fork up-to date
 ==================================
+
+..  _contribute-edit-locally-more-changes-explanation:
 
 Explanation
 -----------
@@ -172,6 +176,8 @@ So, running the following will not get the latest changes:
 because origin points to your fork.
 
 
+..  _contribute-edit-locally-more-changes-now:
+
 Do it now
 ---------
 
@@ -195,6 +201,8 @@ so next time it is enough to do:
 
 Now, continue with step 5 (create branch) in the first section of this page.
 
+
+..  _docs-contribute-git-docker-information:
 
 More information
 ================

--- a/Documentation/Howto/EditOnGithub.rst
+++ b/Documentation/Howto/EditOnGithub.rst
@@ -121,6 +121,8 @@ Scroll down to "Improving documentation":
     :class: with-border with-shadow
 
 
+..  _docs-contribute-github-method-next-steps:
+
 Next Steps
 ==========
 

--- a/Documentation/Howto/Migration/Index.rst
+++ b/Documentation/Howto/Migration/Index.rst
@@ -184,6 +184,8 @@ PHP-based rendering tool:
     should be renamed to use a :file:`.rst.txt` extension instead.
 
 
+..  _migrate-render-documentation-files:
+
 Render your Documentation files locally
 =======================================
 

--- a/Documentation/Howto/RenderingDocs/Index.rst
+++ b/Documentation/Howto/RenderingDocs/Index.rst
@@ -58,6 +58,8 @@ Make sure that `Docker <https://www.docker.com/>`__ is installed on your system.
 
 ..  include:: /_Includes/_LocalRendering.rst.txt
 
+..  _rendering-docs-publishing-extension-documentation:
+
 Publishing extension documentation to docs.typo3.org
 ====================================================
 

--- a/Documentation/Howto/RenderingDocs/Watch.rst
+++ b/Documentation/Howto/RenderingDocs/Watch.rst
@@ -77,6 +77,8 @@ you can create a bash alias like:
     You can do this by changing the :bash:`-p` parameter, e.g. to
     :bash:`-p 8080:1337` to use TCP port `8080` on your host system.
 
+..  _rendering-wysiwyg-docker-compose:
+
 Docker compose
 ==============
 
@@ -102,6 +104,8 @@ development environment, you can add a service for the live rendering like this:
     Render guides was never optimized for long running services. You might need
     to restart the container from time to time to free up resources.
 
+..  _rendering-wysiwyg-ddev:
+
 DDEV
 ====
 
@@ -109,6 +113,8 @@ For integration with DDEV projects, a DDEV addon has been created at https://git
 This can be used to automatically start the live documentation preview within the DDEV project at http://<yourproject>.ddev.site:1337/
 whenever you start that project, and can directly view and work on documentation alongside the project.
 In this environment, users do not even need to execute a manual `docker run` command anymore, and have full integration at hand.
+
+..  _rendering-wysiwyg-limitations:
 
 Limitations
 ===========

--- a/Documentation/Howto/WritingDocForExtension/ContributeToThirdPartyExtension.rst
+++ b/Documentation/Howto/WritingDocForExtension/ContributeToThirdPartyExtension.rst
@@ -37,6 +37,8 @@ mentioned in :ref:`file-structure-general`.
 To find the repository, use one of these methods:
 
 
+..  _contribute-to-3rdparty-extension-find-the-source-method-1:
+
 Method 1: Find the Source on docs.typo3.org
 -------------------------------------------
 
@@ -46,6 +48,8 @@ in the footer.
 Sometimes the metadata in Settings.cfg in a Documentation
 project is not filled out and this link is missing. Then, you can use Method 2.
 
+
+..  _contribute-to-3rdparty-extension-find-the-source-method-2:
 
 Method 2: Find the Source on https://extensions.typo3.org
 ---------------------------------------------------------
@@ -79,16 +83,22 @@ example indexed_search, form, impexp, etc.
 
 ..  index:: Third-party extensions; Find the manual
 
+..  _contribute-to-3rdparty-extension-find-rendered-manual:
+
 Find the rendered manual
 ========================
 
 You can also find the rendered documentation:
+
+..  _contribute-to-3rdparty-extension-find-rendered-manual-method-1:
 
 Method 1: Find rendered manual on docs.typo3.org
 ------------------------------------------------
 
 Go to:
 `Extensions by extension key <https://docs.typo3.org/typo3cms/extensions/Index.html>`__
+
+..  _contribute-to-3rdparty-extension-find-rendered-manual-method-2:
 
 Method 2: Find rendered manual on https://extensions.typo3.org
 --------------------------------------------------------------
@@ -116,6 +126,8 @@ Method 2: Find rendered manual on https://extensions.typo3.org
 ..  index::
     Third-party extensions; Contribution guide
     Files; CONTRIBUTING.md
+
+..  _contribute-to-3rdparty-extension-follow-contribution-guide:
 
 Follow the contribution guide
 =============================

--- a/Documentation/Howto/WritingDocForExtension/FAQ.rst
+++ b/Documentation/Howto/WritingDocForExtension/FAQ.rst
@@ -9,6 +9,8 @@ FAQ
 
 ..  rst-class:: panel panel-default
 
+..  _faq-for-extension-authors-where-link-my:
+
 Where is the link to my documentation in the TYPO3 extension repository?
 ========================================================================
 
@@ -19,6 +21,8 @@ Long answer: the documentation of all extensions is exposed by an API which is c
 Finally the TER will only link to documentation with a matching version, so make sure that there actually is a documentation version for each of your extension version. See :ref:`reregister-versions` to publish documentation for already released versions.
 
 ..  rst-class:: panel panel-default
+
+..  _faq-for-extension-authors-i-am-missing:
 
 I am missing some documentation for extension versions
 ======================================================
@@ -43,6 +47,8 @@ This can be fixed by following these steps:
 #.  You can regenerate existing versions of the documentation by following: `Reregister versions <reregister-versions>`_
 
 ..  rst-class:: panel panel-default
+
+..  _faq-for-extension-authors-why-documentation-provide:
 
 Why Does the Documentation not provide a title?
 ===============================================
@@ -75,6 +81,8 @@ You must add the project title to your :file:`Settings.cfg`:
 
 ..  rst-class:: panel panel-default
 
+..  _faq-for-extension-authors-i-find-my:
+
 How do I find my new rendered documentation?
 ============================================
 
@@ -86,6 +94,8 @@ There are several possibilities:
 
 
 ..  rst-class:: panel panel-default
+
+..  _faq-for-extension-authors-possible-highjack-extension:
 
 Is it possible to highjack extension documentation?
 ===================================================
@@ -109,6 +119,8 @@ See :ref:`webhook` for more information.
 
 ..  rst-class:: panel panel-default
 
+..  _faq-for-extension-authors-way-manually-trigger:
+
 Is there a way to manually trigger documentation rendering aside from a Git repository push?
 ============================================================================================
 
@@ -122,6 +134,8 @@ recommend the usage of the webhook.
 
 
 ..  rst-class:: panel panel-default
+
+..  _faq-for-extension-authors-documentation-independent-ter:
 
 Is the documentation independent of the TER?
 ============================================
@@ -138,6 +152,8 @@ documentation rendering.
 
 
 ..  rst-class:: panel panel-default
+
+..  _faq-for-extension-authors-should-i-add:
 
 Should I add a link to the documentation in TER?
 ================================================
@@ -243,6 +259,8 @@ A link to the Issues will then be available footer section.
 
 Example extension: `news <https://docs.typo3.org/typo3cms/extensions/news/>`__
 
+
+..  _faq-for-extension-authors-further-questions:
 
 Further Questions?
 ==================

--- a/Documentation/Howto/WritingDocForExtension/Index.rst
+++ b/Documentation/Howto/WritingDocForExtension/Index.rst
@@ -64,6 +64,8 @@ for publishing. In case the Team has questions, please follow the thread
 generated for your extension in the `TYPO3 slack organization <https://typo3.org/community/meet/chat-slack>`_
 in channel `#typo3-documentation <https://typo3.slack.com/archives/C028JEPJL>`_.
 
+..  _writing-doc-for-ext-start-version-numbers:
+
 Version numbers
 ===============
 

--- a/Documentation/Maintainers/BackportChanges.rst
+++ b/Documentation/Maintainers/BackportChanges.rst
@@ -21,6 +21,8 @@ backported.
 
 Here are some tips and conventions:
 
+..  _backport-changes-community-user-should:
+
 Community user: What should I do if I found an error in the documentation that applies to several versions?
 ===========================================================================================================
 
@@ -46,6 +48,8 @@ request for the back versions.
     only be backported to the latest LTS release.
 
 
+..  _backport-changes-merger-pull-request:
+
 Merger: The pull request needs to be backported, what should I do?
 ==================================================================
 
@@ -57,6 +61,8 @@ add the corresponding labels :guilabel:`backport 12.4` and
 :guilabel:`backport 11.5`. The labels will trigger an automatic backport once
 the current pull request is merged or the label is added to an already merged
 pull request.
+
+..  _backport-changes-automatic-backports-work:
 
 How do automatic backports work
 ===============================
@@ -71,6 +77,8 @@ the backport. This pull request can be approved and merged manually.
 If the backport fails, a comment will be added to the original pull request. The
 label :guilabel:`backport failed` will be added to the original pull request and
 manual cherry-picking is required.
+
+..  _backport-changes-version:
 
 Up to which version?
 ====================
@@ -89,6 +97,8 @@ There may be reasons to do this differently:
 
 
 ..  index:: GitHub; Squash and merge
+
+..  _backport-changes-merge:
 
 How to merge?
 =============
@@ -113,6 +123,8 @@ additional authors is automatically added to the commit.
 
 
 ..  index:: GitHub; Backport
+
+..  _backport-changes-backport-manually:
 
 How to backport manually?
 =========================

--- a/Documentation/Maintainers/Changelog.rst
+++ b/Documentation/Maintainers/Changelog.rst
@@ -22,6 +22,8 @@ New issues here should be treated with priority.
 
 ..  index:: pair: Updates; Commit messages
 
+..  _howto-update-docs-commit-messages:
+
 Commit messages
 ===============
 

--- a/Documentation/Maintainers/NewMajorCoreVersion.rst
+++ b/Documentation/Maintainers/NewMajorCoreVersion.rst
@@ -9,6 +9,8 @@ Branching of the docs for a new major LTS version
 
 ..  contents::
 
+..  _new-major-core-versions-create-branches-new:
+
 Create branches for the new LTS version in all versioned official repositories
 ==============================================================================
 

--- a/Documentation/Reference/ReStructuredText/Code/Codeblocks.rst
+++ b/Documentation/Reference/ReStructuredText/Code/Codeblocks.rst
@@ -129,8 +129,12 @@ will fail.
     See also the official
     `sphinx documentation on code-blocks <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block>`__.
 
+..  _writing-rest-codeblocks-with-syntax-highlighting-examples:
+
 Examples
 ========
+
+..  _writing-rest-codeblocks-with-syntax-highlighting-examples-simple-code:
 
 A simple code block with syntax highlighting
 --------------------------------------------
@@ -167,6 +171,8 @@ A simple code block with syntax highlighting
                  'Configuration/TypoScript',
                  'Site Package'
             );
+
+..  _writing-rest-codeblocks-with-syntax-highlighting-examples-code-block:
 
 Code block with line numbers and highlighting of one line
 ---------------------------------------------------------
@@ -209,6 +215,8 @@ Code block with line numbers and highlighting of one line
                  'Site Package'
             );
 
+..  _writing-rest-codeblocks-with-syntax-highlighting-examples-code-blocks:
+
 Use code blocks containing diffs
 --------------------------------
 
@@ -243,6 +251,8 @@ To emphasize changes that should be made:
     You can use diff tools such as the
     `bartlweb diff file generator <https://tools.bartlweb.net/diff/>`__. Make
     sure to use the type :code:`unified context`
+
+..  _writing-rest-codeblocks-with-syntax-highlighting-examples-show-directory:
 
 Show a directory tree
 ---------------------
@@ -335,6 +345,8 @@ and a :rst:`literalinclude` directive.
 ..  guides:codeblock-languages::
 
 
+..  _writing-rest-codeblocks-with-syntax-highlighting-literalinclude:
+
 Literalinclude
 ==============
 
@@ -420,6 +432,8 @@ In the XML and HTML markup languages, which make extensive use of angle
 brackets, the comment tag :html:`<!-- placeholder-name -->` is used to insert
 placeholders. A `<placeholder-name>` looks like a regular element and would lead to confusion.
 
+
+..  _writing-rest-codeblocks-with-syntax-highlighting-outdated-code:
 
 Outdated code block formats
 ===========================

--- a/Documentation/Reference/ReStructuredText/Code/Confval.rst
+++ b/Documentation/Reference/ReStructuredText/Code/Confval.rst
@@ -34,6 +34,8 @@ each context.
 Examples
 ========
 
+..  _rest-confval-examples-required-configuration-value:
+
 Required configuration value
 ----------------------------
 
@@ -52,6 +54,8 @@ Required configuration value
         :type: string or LLL reference
 
         The name of the field as shown in the form.
+
+..  _rest-confval-examples-example-configuration-value:
 
 Example: Configuration value with default value and custom parameter
 --------------------------------------------------------------------
@@ -73,6 +77,8 @@ Example: Configuration value with default value and custom parameter
         :Path: :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['fileCreateMask']`
 
         File mode mask for Unix file systems (when files are uploaded/created).
+
+..  _rest-confval-confval-directive-api:
 
 Confval directive API
 =====================
@@ -121,6 +127,8 @@ All other attributes are output the way they are written:
         :Path: :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['fileCreateMask']`
 
         Lorem Ipsum Dolor sit
+
+..  _rest-confval-confval-menu:
 
 Confval menu
 ============
@@ -184,6 +192,8 @@ the same page and want to list them in separate menus:
             :default: 'Hello World'
 
             Some Description
+
+..  _rest-confval-confval-menu-directive:
 
 Confval-menu directive API
 ==========================

--- a/Documentation/Reference/ReStructuredText/Content/Accordion.rst
+++ b/Documentation/Reference/ReStructuredText/Content/Accordion.rst
@@ -62,6 +62,8 @@ Accordion
 
             Placeholder content for this accordion [..]
 
+..  _rest-accordion-accordion-closed:
+
 Accordion all closed
 ====================
 
@@ -109,6 +111,8 @@ Accordion all closed
             :header-level: 3
 
              Let's imagine this being filled with some actual content.
+
+..  _rest-accordion-accordion-complex-content:
 
 Accordion with complex content
 ==============================

--- a/Documentation/Reference/ReStructuredText/Content/Admonitions.rst
+++ b/Documentation/Reference/ReStructuredText/Content/Admonitions.rst
@@ -10,10 +10,14 @@ The following directives are called Admonitions. You
 can use them to point out additional or important
 information.
 
+..  _rest-admonitions-examples:
+
 Examples
 ========
 
 ..  index:: reST directives; seealso
+
+..  _rest-admonitions-examples-see:
 
 See also
 --------
@@ -29,6 +33,8 @@ See also
 
 ..  index:: reST directives; note
 
+..  _rest-admonitions-examples-note:
+
 Note
 ----
 
@@ -42,6 +48,8 @@ Note
 
 
 ..  index:: reST directives; tip
+
+..  _rest-admonitions-examples-tip:
 
 Tip
 ---
@@ -58,6 +66,8 @@ You may also use the admonition **hint**, but this is very similar
 and **tip** is more commonly used in the documentation.
 
 ..  index:: reST directives; warning
+
+..  _rest-admonitions-examples-warning:
 
 Warning
 -------
@@ -76,6 +86,8 @@ severity of the warning must be stressed.
 
 ..  index:: reST directives; attention
 
+..  _rest-admonitions-examples-attention:
+
 Attention
 ---------
 
@@ -87,6 +99,8 @@ Attention
 ..  attention::
     An attention
 
+
+..  _rest-admonitions-information:
 
 More Information
 ================

--- a/Documentation/Reference/ReStructuredText/Content/Cards.rst
+++ b/Documentation/Reference/ReStructuredText/Content/Cards.rst
@@ -17,6 +17,8 @@ Cards are used to group content together and provide a brief introduction on a g
     We discourage using containers for cards and suggest to switch to the
     cards directive.
 
+..  _rest-cards-simple-cards:
+
 Simple cards
 ============
 
@@ -60,6 +62,8 @@ Simple cards
             System requirements for the host operation system, including
             it's web server and database and how they should be configured
             prior to installation.
+
+..  _rest-cards-cards-buttons-footer:
 
 Cards with buttons in the footer
 ================================
@@ -163,6 +167,8 @@ Cards with buttons in the footer
             ..  card-footer:: :ref:`Read more <t3editors:content-elements>`
                 :button-style: btn btn-secondary stretched-link
 
+
+..  _rest-cards-cards-images:
 
 Cards with images
 =================

--- a/Documentation/Reference/ReStructuredText/Content/Comments.rst
+++ b/Documentation/Reference/ReStructuredText/Content/Comments.rst
@@ -16,6 +16,8 @@ See http://docutils.sourceforge.net/docs/user/rst/quickref.html#comments
 This means: write `..␠`, that is dot-dot-blank at the beginning of the
 line, taking the indentation level into account.
 
+..  _writing-rest-comments-examples:
+
 Examples
 --------
 

--- a/Documentation/Reference/ReStructuredText/Content/SpecialCharacters.rst
+++ b/Documentation/Reference/ReStructuredText/Content/SpecialCharacters.rst
@@ -1,6 +1,8 @@
 ..  include:: /Includes.rst.txt
 ..  index:: reST; Special characters
 
+..  _reference-re-structured-text-content-special-characters:
+
 ==================
 Special characters
 ==================
@@ -14,6 +16,8 @@ utf-8.
 
 Keep in mind that while you CAN use any Unicode character not all of them will
 be displayed. In general fonts contain glyphs for common characters only.
+
+..  _reference-re-structured-text-content-special-characters-lists-characters:
 
 Some lists of characters
 ========================
@@ -105,9 +109,13 @@ STAR
     :sep:`|`
 
 
+..  _reference-re-structured-text-content-special-characters-u-2420:
+
 Using U+2420 symbol for space
 =============================
 
+
+..  _reference-re-structured-text-content-special-characters-u-2420-code:
 
 Code
 ----
@@ -117,6 +125,8 @@ Code
     *   ``:literal:`␠abc``` → :literal:`␠abc`
     *   ```␠abc``` → `␠abc`
     *   \`\`␠abc\`\` → ``␠abc``
+
+..  _reference-re-structured-text-content-special-characters-u-2420-result:
 
 Result
 ------

--- a/Documentation/Reference/ReStructuredText/Content/Tables.rst
+++ b/Documentation/Reference/ReStructuredText/Content/Tables.rst
@@ -13,6 +13,8 @@ responsive.
 
 ..  index:: reST; Grid table
 
+..  _rest-tables-grid-table:
+
 Grid table
 ==========
 
@@ -43,6 +45,8 @@ create a grid table.
 
 ..  index:: reST; Simple table
 
+..  _rest-tables-simple-table:
+
 Simple table
 ============
 
@@ -68,6 +72,8 @@ http://docutils.sourceforge.net/docs/user/rst/quickref.html#tables
 
 
 ..  index:: reST; CSV table
+
+..  _rest-tables-csv-table:
 
 CSV table
 =========
@@ -95,6 +101,8 @@ https://docutils.sourceforge.io/docs/ref/rst/directives.html#csv-table-1
 
 ..  index::
     reST directives; t3-field-list-table
+
+..  _rest-tables-t3-field-list:
 
 t3-field-list-table tables
 ==========================

--- a/Documentation/Reference/ReStructuredText/Content/Versions.rst
+++ b/Documentation/Reference/ReStructuredText/Content/Versions.rst
@@ -12,6 +12,8 @@ We have 3 directives to mark versions in the manuals.
 The incentive is that information which is important for migration can be marked
 and semi-automatically be removed after one or two versions.
 
+..  _rest-versions-versionadded:
+
 Versionadded
 ============
 
@@ -41,6 +43,8 @@ For emphasis, the directive can also be placed into one of the
         Starting with TYPO3 10.2 hooks and signals have been replaced by a PSR-14 based
         event dispatching system.
 
+..  _rest-versions-deprecated:
+
 Deprecated
 ==========
 
@@ -53,6 +57,8 @@ Deprecated
 ..  deprecated:: 10.2
     The hook shown here is deprecated since TYPO3 10.2 - use a custom
     PSR-15 middleware instead.
+
+..  _rest-versions-versionchanged:
 
 Versionchanged
 ==============

--- a/Documentation/Reference/ReStructuredText/Lists/BignumLists.rst
+++ b/Documentation/Reference/ReStructuredText/Lists/BignumLists.rst
@@ -87,6 +87,8 @@ With Big Numbers
 
 
 
+..  _styled-numbered-lists-big-numbers-tip:
+
 With Big Numbers - Tip
 ======================
 
@@ -119,6 +121,8 @@ Uses the same color as background, that is used in a tip textblock.
 
     More ...
 
+
+..  _styled-numbered-lists-big-numbers-attention:
 
 With Big Numbers - Attention
 =============================
@@ -153,6 +157,8 @@ With Big Numbers - Attention
 
 
 
+..  _styled-numbered-lists-big-numbers-important:
+
 With Big Numbers - Important
 ============================
 
@@ -186,6 +192,8 @@ With Big Numbers - Important
 
 
 
+..  _styled-numbered-lists-big-numbers-warning:
+
 With Big Numbers - Warning
 ==========================
 
@@ -218,6 +226,8 @@ With Big Numbers - Warning
     More ...
 
 
+
+..  _styled-numbered-lists-nested-bignums-xxl:
 
 Nested bignums-xxl > bignums > Normally Styled
 ==============================================
@@ -268,6 +278,8 @@ Nested bignums-xxl > bignums > Normally Styled
         Oh dear, ...
 
 
+
+..  _styled-numbered-lists-examples-nesting:
 
 More Examples of Nesting
 ========================

--- a/Documentation/Reference/ReStructuredText/Lists/BulletLists.rst
+++ b/Documentation/Reference/ReStructuredText/Lists/BulletLists.rst
@@ -39,6 +39,8 @@ Numbered lists:
 
 ..  index:: reST; Bullet list with sublist
 
+..  _rest-unordered-lists-example-1-list:
+
 Example 1: List with sublist items
 ==================================
 

--- a/Documentation/Reference/ReStructuredText/Lists/DefinitionLists.rst
+++ b/Documentation/Reference/ReStructuredText/Lists/DefinitionLists.rst
@@ -7,11 +7,15 @@ Definition lists
 ================
 
 
+..  _styled-definition-lists-list-style-dl:
+
 List style "dl-parameters"
 ==========================
 
 This list style is used in TYPO3 documentation to style the explanation
 and description of parameters. The general markup we use is that of a "definition list".
+
+..  _styled-definition-lists-list-style-dl-example-1-extra:
 
 Example 1: No Extra Styling
 ---------------------------
@@ -46,6 +50,8 @@ This markup works but isn't very readable due to the lack of styling.
 
 
 ..  index:: reST class; dl-parameters
+
+..  _styled-definition-lists-list-style-dl-example-2-nicely:
 
 Example 2: Nicely Styled
 ------------------------
@@ -119,6 +125,8 @@ Sphinx already comes with standard text roles 'emphasis' and 'strong'. 'aspect'
 and 'sep' inherit their properties and are further specialized.
 
 
+
+..  _styled-definition-lists-list-style-dl-example-3-nicely:
 
 Example 3: Nicely styled through labels interfere
 -------------------------------------------------

--- a/Documentation/Reference/ReStructuredText/Lists/ListItemsAsButtons.rst
+++ b/Documentation/Reference/ReStructuredText/Lists/ListItemsAsButtons.rst
@@ -16,6 +16,8 @@ List items as buttons
     is already used in the Sphinx-Python-domain.
 
 
+..  _list-items-as-buttons-work:
+
 How does it work?
 =================
 
@@ -37,8 +39,12 @@ the list like so:
 
 ..  index:: reST classes; horizbuttons
 
+..  _list-items-as-buttons-available-styles:
+
 Available styles
 ================
+
+..  _list-items-as-buttons-available-styles-horizbuttons-attention-m:
 
 horizbuttons-attention-m
 ------------------------
@@ -52,6 +58,8 @@ Like admonition *attention* (blue)
 *   three `with link <#>`__
 
 
+..  _list-items-as-buttons-available-styles-horizbuttons-important-m:
+
 horizbuttons-important-m
 ------------------------
 
@@ -63,6 +71,8 @@ Like admonitions *error*, *important* (yellow)
 *   two
 *   three `with link <#>`__
 
+
+..  _list-items-as-buttons-available-styles-horizbuttons-note-m:
 
 horizbuttons-note-m
 -------------------
@@ -76,6 +86,8 @@ Like admonitions *generic*, *note*, *see also* (neutral, grey)
 *   three `with link <#>`__
 
 
+..  _list-items-as-buttons-available-styles-horizbuttons-primary-m:
+
 horizbuttons-primary-m
 -----------------------
 
@@ -87,6 +99,8 @@ Use the primary = key color (TYPO3 orange)
 *   two
 *   three `with link <#>`__
 
+
+..  _list-items-as-buttons-available-styles-horizbuttons-striking-m:
 
 horizbuttons-striking-m
 -----------------------
@@ -100,6 +114,8 @@ Shall be very striking and unusual, something to not be be overseen.
 *   three `with link <#>`__
 
 
+..  _list-items-as-buttons-available-styles-horizbuttons-tip-m:
+
 horizbuttons-tip-m
 ------------------
 
@@ -111,6 +127,8 @@ Like admonitions *hint*, *tip* (green)
 *   two
 *   three `with link <#>`__
 
+
+..  _list-items-as-buttons-available-styles-horizbuttons-warning-m:
 
 horizbuttons-warning-m
 ----------------------
@@ -124,6 +142,8 @@ Like admonitions *caution*, *danger*, *warning* (red)
 *   three `with link <#>`__
 
 
+..  _list-items-as-buttons-available-styles-horizbuttons-attention-xxl:
+
 horizbuttons-attention-xxl
 --------------------------
 
@@ -135,6 +155,8 @@ Like admonition *attention* (blue)
 *   two
 *   three `with link <#>`__
 
+
+..  _list-items-as-buttons-available-styles-horizbuttons-important-xxl:
 
 horizbuttons-important-xxl
 --------------------------
@@ -148,6 +170,8 @@ Like admonitions *error*, *important* (yellow)
 *   three `with link <#>`__
 
 
+..  _list-items-as-buttons-available-styles-horizbuttons-note-xxl:
+
 horizbuttons-note-xxl
 ---------------------
 
@@ -159,6 +183,8 @@ Like admonitions *generic*, *note*, *see also* (neutral, grey)
 *   two
 *   three `with link <#>`__
 
+
+..  _list-items-as-buttons-available-styles-horizbuttons-primary-xxl:
 
 horizbuttons-primary-xxl
 ------------------------
@@ -172,6 +198,8 @@ Use the primary = key color (TYPO3 orange)
 *   three `with link <#>`__
 
 
+..  _list-items-as-buttons-available-styles-horizbuttons-striking-xxl:
+
 horizbuttons-striking-xxl
 -------------------------
 
@@ -183,6 +211,8 @@ Shall be very striking and unusual, something to not be be overseen.
 *   two
 *   three `with link <#>`__
 
+
+..  _list-items-as-buttons-available-styles-horizbuttons-tip-xxl:
 
 horizbuttons-tip-xxl
 --------------------
@@ -196,6 +226,8 @@ Like admonitions *hint*, *tip* (green)
 *   three `with link <#>`__
 
 
+..  _list-items-as-buttons-available-styles-horizbuttons-warning-xxl:
+
 horizbuttons-warning-xxl
 ------------------------
 
@@ -207,6 +239,8 @@ Like admonitions *caution*, *danger*, *warning* (red)
 *   two
 *   three `with link <#>`__
 
+
+..  _list-items-as-buttons-available-styles-horizbuttons-attention-xxxl:
 
 horizbuttons-attention-xxxl
 ---------------------------
@@ -220,6 +254,8 @@ Like admonition *attention* (blue)
 *   three `with link <#>`__
 
 
+..  _list-items-as-buttons-available-styles-horizbuttons-important-xxxl:
+
 horizbuttons-important-xxxl
 ---------------------------
 
@@ -231,6 +267,8 @@ Like admonitions *error*, *important* (yellow)
 *   two
 *   three `with link <#>`__
 
+
+..  _list-items-as-buttons-available-styles-horizbuttons-note-xxxl:
 
 horizbuttons-note-xxxl
 ----------------------
@@ -244,6 +282,8 @@ Like admonitions *generic*, *note*, *see also* (neutral, grey)
 *   three `with link <#>`__
 
 
+..  _list-items-as-buttons-available-styles-horizbuttons-primary-xxxl:
+
 horizbuttons-primary-xxxl
 -------------------------
 
@@ -255,6 +295,8 @@ Use the primary = key color (TYPO3 orange)
 *   two
 *   three `with link <#>`__
 
+
+..  _list-items-as-buttons-available-styles-horizbuttons-striking-xxxl:
 
 horizbuttons-striking-xxxl
 --------------------------
@@ -268,6 +310,8 @@ Shall be very striking and unusual, something to not be be overseen.
 *   three `with link <#>`__
 
 
+..  _list-items-as-buttons-available-styles-horizbuttons-tip-xxxl:
+
 horizbuttons-tip-xxxl
 ---------------------
 
@@ -279,6 +323,8 @@ Like admonitions *hint*, *tip* (green)
 *   two
 *   three `with link <#>`__
 
+
+..  _list-items-as-buttons-available-styles-horizbuttons-warning-xxxl:
 
 horizbuttons-warning-xxxl
 -------------------------

--- a/Documentation/Reference/ReStructuredText/Menus/ContentMenu.rst
+++ b/Documentation/Reference/ReStructuredText/Menus/ContentMenu.rst
@@ -34,20 +34,28 @@ To limit the header to a given depth:
     :depth: 1
 
 
+..  _content-menu-topic-1:
+
 Topic 1
 =======
 
 Here we go.
+
+..  _content-menu-topic-1-subtopic-1-1:
 
 Subtopic 1.1
 ------------
 
 Here we dive deeper
 
+..  _content-menu-topic-1-subtopic-1-1-subsubtopic-1-1:
+
 Subsubtopic 1.1.1
 ~~~~~~~~~~~~~~~~~
 
 And this is even more specific.
+
+..  _content-menu-topic-2:
 
 Topic 2
 =======
@@ -55,11 +63,15 @@ Topic 2
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
 tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
 
+..  _content-menu-topic-2-subtopic-2-1:
+
 Subtopic 2.1
 ------------
 
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
 tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+
+..  _content-menu-topic-2-subtopic-2-2:
 
 Subtopic 2.2
 ------------
@@ -67,6 +79,8 @@ Subtopic 2.2
 
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
 tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+
+..  _content-menu-topic-2-subtopic-2-2-subsubtopic-2-2:
 
 Subsubtopic 2.2.1
 ~~~~~~~~~~~~~~~~~

--- a/Documentation/Sitemap.rst
+++ b/Documentation/Sitemap.rst
@@ -2,6 +2,8 @@
 
 ..  include:: /Includes.rst.txt
 
+..  _sitemap:
+
 =======
 Sitemap
 =======


### PR DESCRIPTION
Insert a permalink anchor for every section headline that didn't
have one, in the style of surrounding anchors (hierarchical,
kebab-case, derived from the nearest ancestor heading). Orphan
pages are left untouched since they aren't linked to by anchor.

Verified by rendering the full doc set: new anchors show up as
heading ids, no duplicate-target warnings, nothing else changed.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf