### PR TITLE
[TASK] Convert headlines to sentence case

### DIFF
--- a/Documentation/Advanced/CodingGuidelines.rst
+++ b/Documentation/Advanced/CodingGuidelines.rst
@@ -83,8 +83,8 @@ Line length
 
 ..  _editorconfig:
 
-.editorconfig
--------------
+`.editorconfig`
+---------------
 
 
 Most of our documentation projects contain an .editorconfig file.
@@ -240,7 +240,7 @@ For more information, see the open issue:
     reST roles; doc
 ..  _link-to-changelog:
 
-Link to changelog
+Link to Changelog
 =================
 
 Linking to the :doc:`changelog <ext_core:Index>` should not be necessary, if all

--- a/Documentation/Advanced/ReviewPolicy.rst
+++ b/Documentation/Advanced/ReviewPolicy.rst
@@ -16,7 +16,7 @@ to continuously improve our process.
 
 ..  _review-policy-contributors:
 
-Policy for Contributors
+Policy for contributors
 =======================
 
 As outlined in the chapter :ref:`docs-contribute`, contributors can

--- a/Documentation/Basics/BasicPrinciples.rst
+++ b/Documentation/Basics/BasicPrinciples.rst
@@ -7,9 +7,9 @@
 ..  _about:
 ..  _credits:
 
-=================
+================
 Basic principles
-=================
+================
 
 TYPO3 documentation is written in **reStructuredText (reST)** and rendered to
 HTML using a shared toolchain. Most documentation is hosted on

--- a/Documentation/Basics/MdCheatSheet.rst
+++ b/Documentation/Basics/MdCheatSheet.rst
@@ -4,7 +4,7 @@
 ..  _md-cheat-sheet:
 
 ====================
-Markdown Cheat sheet
+Markdown cheat sheet
 ====================
 
 See commonly used Commonmark Markdown Syntax in the
@@ -14,7 +14,7 @@ TYPO3 Documentation Theme:
 
 ..  _md-cheat-sheet-headlines-anchors:
 
-Headlines and Anchors
+Headlines and anchors
 =====================
 
 Each document must have a title of level 1. You can use headers of additional
@@ -78,7 +78,7 @@ Use the standard Markdown syntax for code blocks:
 
 ..  _md-cheat-sheet-images:
 
-Figures and Images
+Figures and images
 ==================
 
 ..  code-block:: md

--- a/Documentation/Basics/RstCheatSheet.rst
+++ b/Documentation/Basics/RstCheatSheet.rst
@@ -6,14 +6,14 @@
 ..  _rest-cheat-sheet:
 
 ===============================================================
-ReST Cheat sheet: Using reStructuredText in TYPO3 Documentation
+reST cheat sheet: using reStructuredText in TYPO3 documentation
 ===============================================================
 
 ..  contents:: Cheat Sheet
 
 ..  _rest-cheat-sheet-headlines-anchors:
 
-Headlines and Anchors
+Headlines and anchors
 =====================
 
 Each reST document must have a title. It is overlined and underlined like this:
@@ -122,7 +122,7 @@ confval menues: :ref:`rest-confval`.
 
 ..  _rest-cheat-sheet-images:
 
-Figures and Images
+Figures and images
 ==================
 
 ..  literalinclude:: /_CodeSnippets/_Figure.rts.txt

--- a/Documentation/Howto/Contribute/HowYouCanHelp.rst
+++ b/Documentation/Howto/Contribute/HowYouCanHelp.rst
@@ -257,7 +257,7 @@ on `Slack`_.
 
 ..  _how-you-can-help-changelog:
 
-Add information from the changelog
+Add information from the Changelog
 ==================================
 
 Each new or changed changelog from the TYPO3 Core creates an issue in the

--- a/Documentation/Howto/EditLocal.rst
+++ b/Documentation/Howto/EditLocal.rst
@@ -5,7 +5,7 @@
 ..  _docs-contribute-git-docker:
 
 ======================================================
-Workflow #2: "Local editing and rendering with Docker"
+Workflow #2: "local editing and rendering with Docker"
 ======================================================
 
 Using your local machine instead of editing documentation on GitHub has many advantages, it includes

--- a/Documentation/Howto/EditOnGithub.rst
+++ b/Documentation/Howto/EditOnGithub.rst
@@ -4,9 +4,9 @@
 ..  index:: pair: Official documentation; "Edit on GitHub"
 ..  _docs-contribute-github-method:
 
-================================
+=============================
 Workflow #1: "Edit on GitHub"
-================================
+=============================
 
 ..  youtube:: wNxO-aXY5Yw
 
@@ -123,7 +123,7 @@ Scroll down to "Improving documentation":
 
 ..  _docs-contribute-github-method-next-steps:
 
-Next Steps
+Next steps
 ==========
 
 *   Look at :ref:`docs-official-how-you-can-help` for more ways to contribute

--- a/Documentation/Howto/Migration/Index.rst
+++ b/Documentation/Howto/Migration/Index.rst
@@ -7,7 +7,7 @@
 ..  _migrate:
 
 =============================================
-Migration: From Sphinx to PHP-based rendering
+Migration: from Sphinx to PHP-based rendering
 =============================================
 
 ..  note::
@@ -186,7 +186,7 @@ PHP-based rendering tool:
 
 ..  _migrate-render-documentation-files:
 
-Render your Documentation files locally
+Render your documentation files locally
 =======================================
 
 Use our Docker container to render your documentation locally. Read more about it in
@@ -394,7 +394,7 @@ and shown on pull requests.
 
 ..  _migrate-glossary:
 
-To be discussed: Index generation (glossary)
+To be discussed: index generation (glossary)
 ============================================
 
 The Sphinx rendering allowed to utilize a syntax like the following to

--- a/Documentation/Howto/Migration/MarkdownToReST.rst
+++ b/Documentation/Howto/Migration/MarkdownToReST.rst
@@ -6,9 +6,9 @@
     docs.typo3.org
 ..  _migrate-markdown-to-rest:
 
-=============================================
-Migration: Markdown to reStructuredText (ReST)
-=============================================
+==============================================
+Migration: Markdown to reStructuredText (reST)
+==============================================
 
 Markdown is very popular and widely used for documentation. However, ReST is more powerful and flexible.
 The TYPO3 documentation toolchain contains a lot of features that are only available with ReST.
@@ -25,7 +25,7 @@ The TYPO3 documentation toolchain supports both formats.
 
 ..  _migrate-markdown-to-rest-conversion:
 
-Converting Markdown to ReST
+Converting Markdown to reST
 ===========================
 
 The first step is to convert the Markdown files to ReST. This can be done using

--- a/Documentation/Howto/RenderingDocs/Index.rst
+++ b/Documentation/Howto/RenderingDocs/Index.rst
@@ -60,8 +60,8 @@ Make sure that `Docker <https://www.docker.com/>`__ is installed on your system.
 
 ..  _rendering-docs-publishing-extension-documentation:
 
-Publishing extension documentation to docs.typo3.org
-====================================================
+Publishing extension documentation to `docs.typo3.org`
+======================================================
 
 For your documentation to be published to https://docs.typo3.org, your
 TYPO3 extension has to have a valid :file:`composer.json` and either a folder

--- a/Documentation/Howto/RenderingDocs/Watch.rst
+++ b/Documentation/Howto/RenderingDocs/Watch.rst
@@ -79,7 +79,7 @@ you can create a bash alias like:
 
 ..  _rendering-wysiwyg-docker-compose:
 
-Docker compose
+Docker Compose
 ==============
 
 If you are using `docker-compose <https://docs.docker.com/compose/>`_ to manage your

--- a/Documentation/Howto/WritingDocForExtension/ContributeToThirdPartyExtension.rst
+++ b/Documentation/Howto/WritingDocForExtension/ContributeToThirdPartyExtension.rst
@@ -26,7 +26,7 @@ it is usually not required to write an issue. You can just submit a pull request
 
 ..  _contribute-to-3rdparty-extension-find-the-source:
 
-Find the Source
+Find the source
 ===============
 
 First, you need to find out where the source is maintained. Usually, this will
@@ -39,8 +39,8 @@ To find the repository, use one of these methods:
 
 ..  _contribute-to-3rdparty-extension-find-the-source-method-1:
 
-Method 1: Find the Source on docs.typo3.org
--------------------------------------------
+Method 1: find the source on `docs.typo3.org`
+---------------------------------------------
 
 In the page of the rendered docs for the extension, click on :guilabel:`Repository`
 in the footer.
@@ -51,8 +51,8 @@ project is not filled out and this link is missing. Then, you can use Method 2.
 
 ..  _contribute-to-3rdparty-extension-find-the-source-method-2:
 
-Method 2: Find the Source on https://extensions.typo3.org
----------------------------------------------------------
+Method 2: find the source on `https://extensions.typo3.org`
+-----------------------------------------------------------
 
 ..  rst-class:: bignums
 
@@ -92,16 +92,16 @@ You can also find the rendered documentation:
 
 ..  _contribute-to-3rdparty-extension-find-rendered-manual-method-1:
 
-Method 1: Find rendered manual on docs.typo3.org
-------------------------------------------------
+Method 1: find rendered manual on `docs.typo3.org`
+--------------------------------------------------
 
 Go to:
 `Extensions by extension key <https://docs.typo3.org/typo3cms/extensions/Index.html>`__
 
 ..  _contribute-to-3rdparty-extension-find-rendered-manual-method-2:
 
-Method 2: Find rendered manual on https://extensions.typo3.org
---------------------------------------------------------------
+Method 2: find rendered manual on `https://extensions.typo3.org`
+----------------------------------------------------------------
 
 ..  rst-class:: bignums
 

--- a/Documentation/Howto/WritingDocForExtension/FAQ.rst
+++ b/Documentation/Howto/WritingDocForExtension/FAQ.rst
@@ -50,7 +50,7 @@ This can be fixed by following these steps:
 
 ..  _faq-for-extension-authors-why-documentation-provide:
 
-Why Does the Documentation not provide a title?
+Why does the documentation not provide a title?
 ===============================================
 
 ..  image:: /_Images/missing-title.png
@@ -167,8 +167,8 @@ somewhere else (not on docs.typo3.org).
 ..  rst-class:: panel panel-default
 ..  _faq-can-i-use-a-readmerst-or-readmemd-instead:
 
-Can I use a README.rst (or README.md) instead?
-==============================================
+Can I use a `README.rst` (or `README.md`) instead?
+==================================================
 
 GitHub (or Gitlab, bitbucket) etc. automatically render a :file:`README.rst` (or .md)
 on the repository homepage.
@@ -262,7 +262,7 @@ Example extension: `news <https://docs.typo3.org/typo3cms/extensions/news/>`__
 
 ..  _faq-for-extension-authors-further-questions:
 
-Further Questions?
+Further questions?
 ==================
 
 Get in touch with us, if you have problems, would like to ask questions or make suggestions.

--- a/Documentation/Howto/WritingDocForExtension/Index.rst
+++ b/Documentation/Howto/WritingDocForExtension/Index.rst
@@ -28,8 +28,8 @@ See :ref:`render-documentation-with-docker` for more information.
 
 ..  _how-to-start-docs-extension:
 
-Use the init command to create the Documentation folder
-=======================================================
+Use the init command to create the `Documentation` folder
+=========================================================
 
 The following Docker command creates some basic documentation
 including the required configuration file :file:`Documentation/guides.xml`:

--- a/Documentation/Howto/WritingDocForExtension/Webhook.rst
+++ b/Documentation/Howto/WritingDocForExtension/Webhook.rst
@@ -138,7 +138,7 @@ these steps:
 ..  index:: Webhooks; Bitbucket
 ..  _webhook-bitbucket-cloud:
 
-Bitbucket Cloud
+Bitbucket cloud
 ===============
 
 To configure a webhook for a Bitbucket repository:
@@ -191,7 +191,7 @@ To configure a webhook for a Bitbucket repository:
 ..  index:: Webhooks; GitLab
 ..  _webhook-gitlab:
 
-GitLab Cloud and Self-Hosted
+GitLab cloud and Self-Hosted
 ============================
 
 To set up a GitLab webhook:
@@ -231,7 +231,7 @@ To set up a GitLab webhook:
 
 ..  _webhook-testing:
 
-Testing Webhooks
+Testing webhooks
 ================
 
 To test webhook configurations before integrating with TYPO3, use:

--- a/Documentation/Maintainers/BackportChanges.rst
+++ b/Documentation/Maintainers/BackportChanges.rst
@@ -23,7 +23,7 @@ Here are some tips and conventions:
 
 ..  _backport-changes-community-user-should:
 
-Community user: What should I do if I found an error in the documentation that applies to several versions?
+Community user: what should I do if I found an error in the documentation that applies to several versions?
 ===========================================================================================================
 
 Apply your changes to the latest version you have verified your change
@@ -50,7 +50,7 @@ request for the back versions.
 
 ..  _backport-changes-merger-pull-request:
 
-Merger: The pull request needs to be backported, what should I do?
+Merger: the pull request needs to be backported, what should I do?
 ==================================================================
 
 When the pull request needs to be backported, add labels for all needed versions

--- a/Documentation/Maintainers/Changelog.rst
+++ b/Documentation/Maintainers/Changelog.rst
@@ -6,7 +6,7 @@
 ..  _update-docs:
 
 ===================================
-Apply changelog entries to the docs
+Apply Changelog entries to the docs
 ===================================
 
 Whenever a change to the TYPO3 Core potentially affects the users a changelog
@@ -43,7 +43,7 @@ their commit message to the issue, for example
     reST directives; deprecated
 ..  _changelog-deprecations:
 
-Deprecations in the changelog
+Deprecations in the Changelog
 =============================
 
 All information about deprecations should be marked with the :rst:`..  deprecated::`
@@ -70,7 +70,7 @@ deprecation hints in later versions.
     reST directives; versionchanged
 ..  _changelog-breaking-changes:
 
-Breaking changes in the changelog
+Breaking changes in the Changelog
 =================================
 
 Ideally a breaking change was prepared by a :ref:`deprecation <changelog-deprecations>`
@@ -111,7 +111,7 @@ in later versions.
     reST directives; versionadded
 ..  _changelog-feature:
 
-New features in the changelog
+New features in the Changelog
 =============================
 
 When adding a new feature to the docs that is not yet availible in all supported

--- a/Documentation/Maintainers/FluidViewHelper.rst
+++ b/Documentation/Maintainers/FluidViewHelper.rst
@@ -48,7 +48,7 @@ the standard rendering process.
 
 ..  _fluid-viewhelper-reference-generation-github-action:
 
-GitHub action "Fluid ViewHelper Documentation"
+GitHub action "Fluid ViewHelper documentation"
 ==============================================
 
 All processes described above are combined for automatic execution as a GitHub

--- a/Documentation/Maintainers/NewMajorCoreVersion.rst
+++ b/Documentation/Maintainers/NewMajorCoreVersion.rst
@@ -80,8 +80,8 @@ new eLTS versions of all repositories:
 
 ..  _new-major-core-versions-startpage:
 
-Update the start page docs.typo3.org for a new major version
-============================================================
+Update the start page `docs.typo3.org` for a new major version
+==============================================================
 
 *   Add the new major version to the main menu:
     https://github.com/TYPO3-Documentation/DocsTypo3Org-Homepage/blob/main/Documentation/_mainMenu.rst.txt
@@ -92,8 +92,8 @@ Update the start page docs.typo3.org for a new major version
 
 ..  _new-major-core-versions-api:
 
-Update api.typo3.org for a new major version
-============================================
+Update `api.typo3.org` for a new major version
+==============================================
 
 *   Add the new TYPO3 LTS version for rendering into
     https://github.com/TYPO3-Documentation/t3docs-ci-deploy/blob/main/.github/workflows/api-typo3-org.yml#L13

--- a/Documentation/Maintainers/Tools.rst
+++ b/Documentation/Maintainers/Tools.rst
@@ -31,8 +31,8 @@ ff.
 
 ..  _tools-of-the-documentation-team-api:
 
-api.typo3.org
-=============
+`api.typo3.org`
+===============
 
 ..  _tools-of-the-documentation-team-api-landing:
 

--- a/Documentation/Reference/FileStructure.rst
+++ b/Documentation/Reference/FileStructure.rst
@@ -15,8 +15,8 @@ be rendered with the :ref:`rendering toolchain <rendering-docs>`.
 
 ..  _file-structure-general:
 
-Prerequisites for rendering documentation to docs.typo3.org
-===========================================================
+Prerequisites for rendering documentation to `docs.typo3.org`
+=============================================================
 
 In order for the documentation to be rendered, you need at least
 
@@ -201,7 +201,7 @@ It is an almost empty file that is automatically filled during rendering.
 ..  _settings-guides-xml:
 
 Settings: :file:`Documentation/guides.xml`
---------------------------------------------
+------------------------------------------
 
 This file contains the metadata and configuration for the rendering with the
 TYPO3 theme.
@@ -220,7 +220,7 @@ Example:
 
 ..  _full-documentation-md:
 
-Full documentation in reST markdown
+Full documentation in reST Markdown
 ===================================
 
 The TYPO3 documentation rendering pipeline supports rendering of CommonMark

--- a/Documentation/Reference/GuidesXml.rst
+++ b/Documentation/Reference/GuidesXml.rst
@@ -2,9 +2,9 @@
 
 ..  _guides-xml:
 
-===========================================
-Configuration of the rendering - guides.xml
-===========================================
+=============================================
+Configuration of the rendering - `guides.xml`
+=============================================
 
 This XML file contains meta information and configuration used during rendering
 of a manual.
@@ -17,8 +17,8 @@ of a manual.
 
 ..  _guides-xml-init:
 
-Init new guides.xml
-===================
+Init new `guides.xml`
+=====================
 
 If you start a new documentation guide, for example in a TYPO3 extension, use the
 `init` command:
@@ -34,8 +34,8 @@ And follow the interactive question.
 
 ..  _guides-xml-api:
 
-guides.xml API
-==============
+`guides.xml` API
+================
 
 ..  confval-menu::
     :display: tree

--- a/Documentation/Reference/ReStructuredText/Code/Confval.rst
+++ b/Documentation/Reference/ReStructuredText/Code/Confval.rst
@@ -4,9 +4,9 @@
     reST; Configuration values
 ..  _rest-confval:
 
-===============================
+==============================
 Configuration values (confval)
-===============================
+==============================
 
 The :rst:`confval` directive can be used to document configuration values
 in a structured way, independent of the programming language.
@@ -57,7 +57,7 @@ Required configuration value
 
 ..  _rest-confval-examples-example-configuration-value:
 
-Example: Configuration value with default value and custom parameter
+Example: configuration value with default value and custom parameter
 --------------------------------------------------------------------
 
 ..  confval:: fileCreateMask

--- a/Documentation/Reference/ReStructuredText/Content/Admonitions.rst
+++ b/Documentation/Reference/ReStructuredText/Content/Admonitions.rst
@@ -3,7 +3,7 @@
 ..  _rest-admonitions:
 
 ===============================================
-Admonitions: Tip, Note, Warning, See also,  etc
+Admonitions: tip, note, warning, see also,  etc
 ===============================================
 
 The following directives are called Admonitions. You
@@ -102,7 +102,7 @@ Attention
 
 ..  _rest-admonitions-information:
 
-More Information
+More information
 ================
 
 The admonitions listed here are the most commonly used in the TYPO3 documentation.

--- a/Documentation/Reference/ReStructuredText/Content/Index.rst
+++ b/Documentation/Reference/ReStructuredText/Content/Index.rst
@@ -4,7 +4,7 @@
 ..  _rest-content:
 
 ==================================
-Directives (reST Content elements)
+Directives (reST content elements)
 ==================================
 
 ..  toctree::

--- a/Documentation/Reference/ReStructuredText/Content/Tables.rst
+++ b/Documentation/Reference/ReStructuredText/Content/Tables.rst
@@ -104,8 +104,8 @@ https://docutils.sourceforge.io/docs/ref/rst/directives.html#csv-table-1
 
 ..  _rest-tables-t3-field-list:
 
-t3-field-list-table tables
-==========================
+`t3-field-list-table` tables
+============================
 
 `t3-field-list-table` is a custom directive, created by the t3SphinxThemeRtd
 template. If you want your .rst file to be correctly rendered on other

--- a/Documentation/Reference/ReStructuredText/Content/Tabs.rst
+++ b/Documentation/Reference/ReStructuredText/Content/Tabs.rst
@@ -2,9 +2,9 @@
 ..  index:: reST; Tabs
 ..  _rest-tabs:
 
-=====
+====
 Tabs
-=====
+====
 
 They provide a compact way to present a topic from different perspectives, with
 each perspective presented in a tab. When the reader changes tabs, this change

--- a/Documentation/Reference/ReStructuredText/Content/ViewHelper.rst
+++ b/Documentation/Reference/ReStructuredText/Content/ViewHelper.rst
@@ -3,7 +3,7 @@
 ..  _viewhelper:
 
 =============================================
-Display Fluid ViewHelpers in ReStructuredText
+Display Fluid ViewHelpers in reStructuredText
 =============================================
 
 The special `..  typo3:viewhelper::` directive can be used to display the
@@ -20,7 +20,7 @@ on how to generate the input file.
 
 ..  _viewhelper-example:
 
-Example: Display a ViewHelper from a JSON include
+Example: display a ViewHelper from a JSON include
 =================================================
 
 ..  code-block:: rst

--- a/Documentation/Reference/ReStructuredText/Graphics/ImageAlignment.rst
+++ b/Documentation/Reference/ReStructuredText/Graphics/ImageAlignment.rst
@@ -3,9 +3,9 @@
 ..  include:: /Includes.rst.txt
 ..  _image-float-alignment:
 
-==========================================
+=======================================
 Image and figure floating and alignment
-==========================================
+=======================================
 
 ..  versionadded:: 0.37.0
     Float and alignment support for images and figures was introduced in
@@ -103,7 +103,7 @@ without horizontal scrolling.
 
 ..  _image-float-example-8:
 
-Example 8: Figure floated left
+Example 8: figure floated left
 ------------------------------
 
 ..  figure:: /_Images/a4.jpg
@@ -136,8 +136,8 @@ Typesetting requires one or more fonts.
 
 ..  _image-float-example-9:
 
-Example 9: Figure aligned right
---------------------------------
+Example 9: figure aligned right
+-------------------------------
 
 ..  figure:: /_Images/a4.jpg
     :alt: Example figure aligned right
@@ -169,8 +169,8 @@ Typesetting requires one or more fonts.
 
 ..  _image-float-example-10:
 
-Example 10: Image floated left with shadow
--------------------------------------------
+Example 10: image floated left with shadow
+------------------------------------------
 
 ..  image:: /_Images/a4.jpg
     :alt: Example image floated left
@@ -199,7 +199,7 @@ Typesetting requires one or more fonts.
 ..  _image-float-best-practices:
 
 Best practices for floating
-============================
+===========================
 
 *   Always use ``..  rst-class:: clear-both`` after floated content to prevent
     layout issues with subsequent sections

--- a/Documentation/Reference/ReStructuredText/Graphics/ImageZoom.rst
+++ b/Documentation/Reference/ReStructuredText/Graphics/ImageZoom.rst
@@ -3,9 +3,9 @@
 ..  include:: /Includes.rst.txt
 ..  _image-zoom:
 
-===================================
+================================
 Image zoom and lightbox features
-===================================
+================================
 
 ..  versionadded:: 0.36.0
     The image zoom feature was introduced in render-guides version 0.36.0.
@@ -87,8 +87,8 @@ Usage examples
 
 ..  _image-zoom-example-3:
 
-Example 3: Lightbox zoom
--------------------------
+Example 3: lightbox zoom
+------------------------
 
 ..  figure:: /_Images/a4.jpg
     :alt: Example screenshot
@@ -108,8 +108,8 @@ Example 3: Lightbox zoom
 
 ..  _image-zoom-example-4:
 
-Example 4: Gallery mode with grouped images
---------------------------------------------
+Example 4: gallery mode with grouped images
+-------------------------------------------
 
 ..  code-block:: rst
 
@@ -129,8 +129,8 @@ Example 4: Gallery mode with grouped images
 
 ..  _image-zoom-example-5:
 
-Example 5: Inline scroll-wheel zoom
-------------------------------------
+Example 5: inline scroll-wheel zoom
+-----------------------------------
 
 ..  code-block:: rst
 
@@ -142,8 +142,8 @@ Example 5: Inline scroll-wheel zoom
 
 ..  _image-zoom-example-6:
 
-Example 6: Magnifier lens
---------------------------
+Example 6: magnifier lens
+-------------------------
 
 ..  code-block:: rst
 
@@ -155,8 +155,8 @@ Example 6: Magnifier lens
 
 ..  _image-zoom-example-7:
 
-Example 7: Hidden zoom indicator
----------------------------------
+Example 7: hidden zoom indicator
+--------------------------------
 
 ..  code-block:: rst
 
@@ -170,7 +170,7 @@ Example 7: Hidden zoom indicator
 ..  _image-zoom-accessibility:
 
 Accessibility considerations
-=============================
+============================
 
 All zoom modes are designed with accessibility in mind:
 

--- a/Documentation/Reference/ReStructuredText/Graphics/Images.rst
+++ b/Documentation/Reference/ReStructuredText/Graphics/Images.rst
@@ -6,7 +6,7 @@
 ..  _images:
 
 ==================================
-Using images in ReST documentation
+Using images in reST documentation
 ==================================
 
 You can use the `The example screenshot project <https://docs.typo3.org/permalink/h2document:screenshot-project>`_.
@@ -20,7 +20,7 @@ screenshot tool since TYPO3 v11 as it proved to be to complicated to maintain.
 
 ..  _rest-images:
 
-Images and figures in Rest
+Images and figures in reST
 ==========================
 
 We recommend to use the `..  figure::` directive. It works just like
@@ -49,7 +49,7 @@ Additional parameters can be found on the docutils page `reStructuredText Direct
 
 ..  _image-scaled:
 
-Example 1: Scaled image with shadow and link target
+Example 1: scaled image with shadow and link target
 ===================================================
 
 ..  image:: /_Images/a4.jpg
@@ -69,7 +69,7 @@ Example 1: Scaled image with shadow and link target
 
 ..  _image-caption:
 
-Example 2: Image with caption and fixed width
+Example 2: image with caption and fixed width
 =============================================
 
 ..  figure:: /_Images/a4.jpg

--- a/Documentation/Reference/ReStructuredText/InlineMarkup/Index.rst
+++ b/Documentation/Reference/ReStructuredText/InlineMarkup/Index.rst
@@ -4,7 +4,7 @@
 ..  _rest-inline-markup:
 
 ====================================
-Inline Markup in TYPO3 Documentation
+Inline markup in TYPO3 documentation
 ====================================
 
 In general we support any inline markup in reStructuredText that was previously

--- a/Documentation/Reference/ReStructuredText/Links/Api.rst
+++ b/Documentation/Reference/ReStructuredText/Links/Api.rst
@@ -3,7 +3,7 @@
 ..  _links-api:
 
 ================================================
-API links: More information on TYPO3 PHP classes
+API links: more information on TYPO3 PHP classes
 ================================================
 
 At https://api.typo3.org/ all classes and interfaces of the
@@ -15,8 +15,8 @@ explicit links to these:
 
 ..  _links-api-explicit:
 
-Explicit links to api.typo3.org
-===============================
+Explicit links to `api.typo3.org`
+=================================
 
 ..  literalinclude:: _Api.rst.txt
 

--- a/Documentation/Reference/ReStructuredText/Links/ExampleLinks.rst
+++ b/Documentation/Reference/ReStructuredText/Links/ExampleLinks.rst
@@ -4,9 +4,9 @@
 ..  index:: reST; Preventing links
 ..  _preventing-links:
 
-===========================
-Example domain: example.org
-===========================
+=============================
+Example domain: `example.org`
+=============================
 
 The renderer automatically converts simple URLs into links. This can be unintentional
 in certain contexts, for example when using a

--- a/Documentation/Reference/ReStructuredText/Links/Index.rst
+++ b/Documentation/Reference/ReStructuredText/Links/Index.rst
@@ -4,7 +4,7 @@
 ..  _how-to-document-hyperlinks:
 
 ==========================
-Links in ReStructured Text
+Links in ReStructured text
 ==========================
 
 

--- a/Documentation/Reference/ReStructuredText/Lists/BignumLists.rst
+++ b/Documentation/Reference/ReStructuredText/Lists/BignumLists.rst
@@ -11,7 +11,7 @@ Styled numbered sections (bignums)
 
 ..  _big-nums-xxl:
 
-With XXL Big Numbers
+With XXL big numbers
 ====================
 
 *Source:* :
@@ -50,7 +50,7 @@ With XXL Big Numbers
 
 ..  _big-nums:
 
-With Big Numbers
+With big numbers
 ================
 
 *Source:* :
@@ -89,7 +89,7 @@ With Big Numbers
 
 ..  _styled-numbered-lists-big-numbers-tip:
 
-With Big Numbers - Tip
+With big numbers - tip
 ======================
 
 Uses the same color as background, that is used in a tip textblock.
@@ -124,8 +124,8 @@ Uses the same color as background, that is used in a tip textblock.
 
 ..  _styled-numbered-lists-big-numbers-attention:
 
-With Big Numbers - Attention
-=============================
+With big numbers - attention
+============================
 
 *Source:* :
 
@@ -159,7 +159,7 @@ With Big Numbers - Attention
 
 ..  _styled-numbered-lists-big-numbers-important:
 
-With Big Numbers - Important
+With big numbers - important
 ============================
 
 
@@ -194,7 +194,7 @@ With Big Numbers - Important
 
 ..  _styled-numbered-lists-big-numbers-warning:
 
-With Big Numbers - Warning
+With big numbers - warning
 ==========================
 
 *Source:* :
@@ -229,8 +229,8 @@ With Big Numbers - Warning
 
 ..  _styled-numbered-lists-nested-bignums-xxl:
 
-Nested bignums-xxl > bignums > Normally Styled
-==============================================
+Nested `bignums-xxl` > `bignums` > normally styled
+==================================================
 
 
 *Source:* :
@@ -281,7 +281,7 @@ Nested bignums-xxl > bignums > Normally Styled
 
 ..  _styled-numbered-lists-examples-nesting:
 
-More Examples of Nesting
+More examples of nesting
 ========================
 
 ..  highlight:: shell

--- a/Documentation/Reference/ReStructuredText/Lists/BulletLists.rst
+++ b/Documentation/Reference/ReStructuredText/Lists/BulletLists.rst
@@ -41,7 +41,7 @@ Numbered lists:
 
 ..  _rest-unordered-lists-example-1-list:
 
-Example 1: List with sublist items
+Example 1: list with sublist items
 ==================================
 
 ..  code-block:: rst

--- a/Documentation/Reference/ReStructuredText/Lists/DefinitionLists.rst
+++ b/Documentation/Reference/ReStructuredText/Lists/DefinitionLists.rst
@@ -17,7 +17,7 @@ and description of parameters. The general markup we use is that of a "definitio
 
 ..  _styled-definition-lists-list-style-dl-example-1-extra:
 
-Example 1: No Extra Styling
+Example 1: no extra styling
 ---------------------------
 
 An example with a standard styling would look like this:
@@ -53,7 +53,7 @@ This markup works but isn't very readable due to the lack of styling.
 
 ..  _styled-definition-lists-list-style-dl-example-2-nicely:
 
-Example 2: Nicely Styled
+Example 2: nicely styled
 ------------------------
 
 Source::
@@ -128,7 +128,7 @@ and 'sep' inherit their properties and are further specialized.
 
 ..  _styled-definition-lists-list-style-dl-example-3-nicely:
 
-Example 3: Nicely styled through labels interfere
+Example 3: nicely styled through labels interfere
 -------------------------------------------------
 
 Let's say you want to place labels in front of each definition list

--- a/Documentation/Reference/ReStructuredText/Lists/DirectoryTree.rst
+++ b/Documentation/Reference/ReStructuredText/Lists/DirectoryTree.rst
@@ -13,8 +13,8 @@ extensions or projects.
 
 ..  _writing-rest-directory-tree-example-basic:
 
-Example: A basic directory tree, two levels expanded
-=====================================================
+Example: a basic directory tree, two levels expanded
+====================================================
 
 ..  directory-tree::
     :level: 2
@@ -70,7 +70,7 @@ Example: A basic directory tree, two levels expanded
 
 ..  _writing-rest-directory-tree-example-empty-folders:
 
-Example: A page tree with empty folders
+Example: a page tree with empty folders
 =======================================
 
 ..  directory-tree::

--- a/Documentation/Reference/ReStructuredText/Lists/ListItemsAsButtons.rst
+++ b/Documentation/Reference/ReStructuredText/Lists/ListItemsAsButtons.rst
@@ -46,8 +46,8 @@ Available styles
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-attention-m:
 
-horizbuttons-attention-m
-------------------------
+`horizbuttons-attention-m`
+--------------------------
 
 Like admonition *attention* (blue)
 
@@ -60,8 +60,8 @@ Like admonition *attention* (blue)
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-important-m:
 
-horizbuttons-important-m
-------------------------
+`horizbuttons-important-m`
+--------------------------
 
 Like admonitions *error*, *important* (yellow)
 
@@ -74,8 +74,8 @@ Like admonitions *error*, *important* (yellow)
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-note-m:
 
-horizbuttons-note-m
--------------------
+`horizbuttons-note-m`
+---------------------
 
 Like admonitions *generic*, *note*, *see also* (neutral, grey)
 
@@ -88,8 +88,8 @@ Like admonitions *generic*, *note*, *see also* (neutral, grey)
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-primary-m:
 
-horizbuttons-primary-m
------------------------
+`horizbuttons-primary-m`
+------------------------
 
 Use the primary = key color (TYPO3 orange)
 
@@ -102,8 +102,8 @@ Use the primary = key color (TYPO3 orange)
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-striking-m:
 
-horizbuttons-striking-m
------------------------
+`horizbuttons-striking-m`
+-------------------------
 
 Shall be very striking and unusual, something to not be be overseen.
 
@@ -116,8 +116,8 @@ Shall be very striking and unusual, something to not be be overseen.
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-tip-m:
 
-horizbuttons-tip-m
-------------------
+`horizbuttons-tip-m`
+--------------------
 
 Like admonitions *hint*, *tip* (green)
 
@@ -130,8 +130,8 @@ Like admonitions *hint*, *tip* (green)
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-warning-m:
 
-horizbuttons-warning-m
-----------------------
+`horizbuttons-warning-m`
+------------------------
 
 Like admonitions *caution*, *danger*, *warning* (red)
 
@@ -144,8 +144,8 @@ Like admonitions *caution*, *danger*, *warning* (red)
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-attention-xxl:
 
-horizbuttons-attention-xxl
---------------------------
+`horizbuttons-attention-xxl`
+----------------------------
 
 Like admonition *attention* (blue)
 
@@ -158,8 +158,8 @@ Like admonition *attention* (blue)
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-important-xxl:
 
-horizbuttons-important-xxl
---------------------------
+`horizbuttons-important-xxl`
+----------------------------
 
 Like admonitions *error*, *important* (yellow)
 
@@ -172,8 +172,8 @@ Like admonitions *error*, *important* (yellow)
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-note-xxl:
 
-horizbuttons-note-xxl
----------------------
+`horizbuttons-note-xxl`
+-----------------------
 
 Like admonitions *generic*, *note*, *see also* (neutral, grey)
 
@@ -186,8 +186,8 @@ Like admonitions *generic*, *note*, *see also* (neutral, grey)
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-primary-xxl:
 
-horizbuttons-primary-xxl
-------------------------
+`horizbuttons-primary-xxl`
+--------------------------
 
 Use the primary = key color (TYPO3 orange)
 
@@ -200,8 +200,8 @@ Use the primary = key color (TYPO3 orange)
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-striking-xxl:
 
-horizbuttons-striking-xxl
--------------------------
+`horizbuttons-striking-xxl`
+---------------------------
 
 Shall be very striking and unusual, something to not be be overseen.
 
@@ -214,8 +214,8 @@ Shall be very striking and unusual, something to not be be overseen.
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-tip-xxl:
 
-horizbuttons-tip-xxl
---------------------
+`horizbuttons-tip-xxl`
+----------------------
 
 Like admonitions *hint*, *tip* (green)
 
@@ -228,8 +228,8 @@ Like admonitions *hint*, *tip* (green)
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-warning-xxl:
 
-horizbuttons-warning-xxl
-------------------------
+`horizbuttons-warning-xxl`
+--------------------------
 
 Like admonitions *caution*, *danger*, *warning* (red)
 
@@ -242,8 +242,8 @@ Like admonitions *caution*, *danger*, *warning* (red)
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-attention-xxxl:
 
-horizbuttons-attention-xxxl
----------------------------
+`horizbuttons-attention-xxxl`
+-----------------------------
 
 Like admonition *attention* (blue)
 
@@ -256,8 +256,8 @@ Like admonition *attention* (blue)
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-important-xxxl:
 
-horizbuttons-important-xxxl
----------------------------
+`horizbuttons-important-xxxl`
+-----------------------------
 
 Like admonitions *error*, *important* (yellow)
 
@@ -270,8 +270,8 @@ Like admonitions *error*, *important* (yellow)
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-note-xxxl:
 
-horizbuttons-note-xxxl
-----------------------
+`horizbuttons-note-xxxl`
+------------------------
 
 Like admonitions *generic*, *note*, *see also* (neutral, grey)
 
@@ -284,8 +284,8 @@ Like admonitions *generic*, *note*, *see also* (neutral, grey)
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-primary-xxxl:
 
-horizbuttons-primary-xxxl
--------------------------
+`horizbuttons-primary-xxxl`
+---------------------------
 
 Use the primary = key color (TYPO3 orange)
 
@@ -298,8 +298,8 @@ Use the primary = key color (TYPO3 orange)
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-striking-xxxl:
 
-horizbuttons-striking-xxxl
---------------------------
+`horizbuttons-striking-xxxl`
+----------------------------
 
 Shall be very striking and unusual, something to not be be overseen.
 
@@ -312,8 +312,8 @@ Shall be very striking and unusual, something to not be be overseen.
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-tip-xxxl:
 
-horizbuttons-tip-xxxl
----------------------
+`horizbuttons-tip-xxxl`
+-----------------------
 
 Like admonitions *hint*, *tip* (green)
 
@@ -326,8 +326,8 @@ Like admonitions *hint*, *tip* (green)
 
 ..  _list-items-as-buttons-available-styles-horizbuttons-warning-xxxl:
 
-horizbuttons-warning-xxxl
--------------------------
+`horizbuttons-warning-xxxl`
+---------------------------
 
 Like admonitions *caution*, *danger*, *warning* (red)
 

--- a/Documentation/Reference/ReStructuredText/Menus/HeadlinesAndSection.rst
+++ b/Documentation/Reference/ReStructuredText/Menus/HeadlinesAndSection.rst
@@ -7,9 +7,9 @@
     pair: reST; Sections
 ..  _headlines-and-sections:
 
-======================
+=====================
 Headlines and anchors
-======================
+=====================
 
 Each reST document must have a title. It is overlined and underlined like this:
 
@@ -59,27 +59,27 @@ They look like this:
 
 ..  _h2-headline:
 
-H2 Headline
+H2 headline
 ===========
 
 ..  _h3-headline:
 
-H3 Headline
+H3 headline
 -----------
 
 ..  _h4-headline:
 
-H4 Headline
+H4 headline
 ~~~~~~~~~~~
 
 ..  _h5-headline:
 
-H5 Headline
+H5 headline
 """""""""""
 
 ..  _h6-headline:
 
-H6 Headline
+H6 headline
 '''''''''''
 
 ..  _syntax-headlines:

--- a/Documentation/Reference/ReStructuredText/Menus/IncludingFiles.rst
+++ b/Documentation/Reference/ReStructuredText/Menus/IncludingFiles.rst
@@ -64,7 +64,7 @@ they had been written directly into the rst file. All markup is respected.
 
 ..  _including-files-example-advanced:
 
-Example: Break up a large file into manageable pieces
+Example: break up a large file into manageable pieces
 =====================================================
 
 In places like the TSconfig reference or TCA reference it is helpful to display

--- a/Documentation/Reference/ReStructuredText/Menus/NavigationTitle.rst
+++ b/Documentation/Reference/ReStructuredText/Menus/NavigationTitle.rst
@@ -3,7 +3,7 @@
 ..  _navigation-title:
 
 =================================================
-Navigation title: A page title displayed in menus
+Navigation title: a page title displayed in menus
 =================================================
 
 It is possible to define a different, usually shorter, title for a page to be

--- a/Documentation/Reference/ScreenshotContainer/Index.rst
+++ b/Documentation/Reference/ScreenshotContainer/Index.rst
@@ -4,7 +4,7 @@
 ..  _screenshot-container:
 
 ==================================
-TYPO3 Screenshots Docker container
+TYPO3 screenshots Docker container
 ==================================
 
 We have prepared a Docker container that you can use to create screenshots


### PR DESCRIPTION
Headlines now follow the documented sentence-case style, respecting
the Glossary.rst preferred-casing dictionary (Backend Users, DB
Check, Changelog, reST, etc.). Bare filenames/domains/identifiers
are wrapped in single backticks instead of being casing-normalized.

Also fixes headline overline/underline rules to match title length
exactly across the whole Documentation tree.

Verified with the full Docker render pipeline.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf