### PR TITLE
[TASK] Prefer single backticks over double

### DIFF
--- a/Documentation/Advanced/CodingGuidelines.rst
+++ b/Documentation/Advanced/CodingGuidelines.rst
@@ -41,12 +41,12 @@ Whitespace and indentation
 *   don't use tabs
 *   one indentation level consists of **four spaces**
 *   code examples use four spaces as indentation level as well
-*   directive and hyperlink target markers use two spaces after ``..``,
-    e.g. ``..  note::`` or ``..  _label:``
+*   directive and hyperlink target markers use two spaces after :rst:`..`,
+    e.g. :rst:`..  note::` or :rst:`..  _label:`
 *   list markers are followed by enough spaces to line up item text at a
-    4-space column: 3 spaces after a single-character marker (``*``, ``-``),
-    2 spaces after a two-character enumerator (``#.``, ``1.``), 1 space
-    after longer enumerators (``10.``)
+    4-space column: 3 spaces after a single-character marker (:rst:`*`, :rst:`-`),
+    2 spaces after a two-character enumerator (:rst:`#.`, :rst:`1.`), 1 space
+    after longer enumerators (:rst:`10.`)
 
 Example:
 

--- a/Documentation/Basics/RstCheatSheet.rst
+++ b/Documentation/Basics/RstCheatSheet.rst
@@ -196,7 +196,7 @@ Escape characters
 =================
 
 If you want to use a character that would normally create reST markup,
-you must escape it with a prepended backslash (``\``).
+you must escape it with a prepended backslash (:rst:`\\`).
 
 ..  code-block:: rst
 

--- a/Documentation/Howto/Migration/MarkdownToReST.rst
+++ b/Documentation/Howto/Migration/MarkdownToReST.rst
@@ -30,7 +30,7 @@ Converting Markdown to reST
 
 The first step is to convert the Markdown files to ReST. This can be done using
 our rendering toolchain. This will convert the Markdown files to ReST format.
-We will use ``Documentation-Migrated`` as the output directory.
+We will use :file:`Documentation-Migrated` as the output directory.
 
 ..  tabs::
 
@@ -55,10 +55,10 @@ We will use ``Documentation-Migrated`` as the output directory.
             New-Item -ItemType Directory -Force -Path ".\Documentation-Migrated"
             docker run --rm --pull always -v ${PWD}:/project -it ghcr.io/typo3-documentation/render-guides:latest --theme=rst --output-format=rst --output Documentation-Migrated
 
-Now we can copy the ``guides.xml`` from the original directory documentation directory to the new directory. And remove the
-option ``input-format="md"``. This will tell the rendering toolchain to use the ReST files instead of the Markdown files.
+Now we can copy the :file:`guides.xml` from the original directory documentation directory to the new directory. And remove the
+option `input-format="md"`. This will tell the rendering toolchain to use the ReST files instead of the Markdown files.
 
-Last step is to swap the directories. Rename the original directory to ``Documentation-Markdown`` and the new directory ``Documentation-Migrated`` to ``Documentation``.
+Last step is to swap the directories. Rename the original directory to :file:`Documentation-Markdown` and the new directory :file:`Documentation-Migrated` to :file:`Documentation`.
 
 The basic migration is now done. Some manual adjustments might be necessary, as the conversion is not perfect.
 

--- a/Documentation/Howto/WritingDocForExtension/Index.rst
+++ b/Documentation/Howto/WritingDocForExtension/Index.rst
@@ -69,8 +69,8 @@ in channel `#typo3-documentation <https://typo3.slack.com/archives/C028JEPJL>`_.
 Version numbers
 ===============
 
-docs.typo3.org does no longer show three level version numbers in form of ``Major.Minor.Patch``.
-Only the first two levels are shown ``Major.Minor``.
+docs.typo3.org does no longer show three level version numbers in form of `Major.Minor.Patch`.
+Only the first two levels are shown `Major.Minor`.
 
 This reduces the amount of documentation while keeping relevant information,
 as patch levels should not introduce breaking changes or new features.
@@ -84,15 +84,15 @@ Supported branches
 
 The rendering supports two branches within repositories:
 
-``main`` / ``master``
+`main` / `master`
     Should contain the current development state, used for upcoming release.
     Every push to these branches triggers a new rendering, available at
     :samp:`https://docs.typo3.org/p/<vendor>/<package>/main/en-us/`.
 
     Both branch names are supported, but result in the same URL.
-    Please use ``main``, ``master`` is only supported for backward compatibility.
+    Please use `main`, `master` is only supported for backward compatibility.
 
-``documentation-draft``
+`documentation-draft`
     Should contain a draft of the documentation.
     Every push to this branch triggers a new rendering, available at
     :samp:`https://docs.typo3.org/p/<vendor>/<package>/draft/en-us/`

--- a/Documentation/Reference/ReStructuredText/Graphics/ImageAlignment.rst
+++ b/Documentation/Reference/ReStructuredText/Graphics/ImageAlignment.rst
@@ -18,10 +18,10 @@ displayed as a standalone block.
 
 There are two ways to apply floating:
 
-1.  **CSS classes** ``:class: float-left`` or ``:class: float-right`` — works on
-    both ``..  image::`` and ``..  figure::`` directives.
-2.  The ``:align:`` **option** — ``:align: left``, ``:align: right``, or ``:align: center``
-    — works on ``..  figure::`` directives (internally mapped to the same CSS
+1.  **CSS classes** :rst:`:class: float-left` or :rst:`:class: float-right` — works on
+    both :rst:`..  image::` and :rst:`..  figure::` directives.
+2.  The :rst:`:align:` **option** — :rst:`:align: left`, :rst:`:align: right`, or :rst:`:align: center`
+    — works on :rst:`..  figure::` directives (internally mapped to the same CSS
     classes).
 
 Both approaches produce the same visual result. Use whichever fits your
@@ -32,8 +32,8 @@ preference.
 Float with CSS classes
 ======================
 
-Add ``float-left`` or ``float-right`` to the ``:class:`` option. You can combine
-these with other classes such as ``with-shadow`` or ``with-border``:
+Add :rst:`float-left` or :rst:`float-right` to the :rst:`:class:` option. You can combine
+these with other classes such as :rst:`with-shadow` or :rst:`with-border`:
 
 ..  code-block:: rst
 
@@ -50,8 +50,8 @@ these with other classes such as ``with-shadow`` or ``with-border``:
 Align option
 ============
 
-The ``:align:`` option on ``..  figure::`` directives supports ``left``, ``right``,
-and ``center``. Values ``left`` and ``right`` produce the same floating behavior
+The :rst:`:align:` option on :rst:`..  figure::` directives supports :rst:`left`, :rst:`right`,
+and :rst:`center`. Values :rst:`left` and :rst:`right` produce the same floating behavior
 as the CSS classes:
 
 ..  code-block:: rst
@@ -64,7 +64,7 @@ as the CSS classes:
 
     Surrounding text will wrap to the left of the image.
 
-Using ``:align: center`` centers the figure without any text wrapping.
+Using :rst:`:align: center` centers the figure without any text wrapping.
 
 ..  _image-float-clearing:
 
@@ -72,7 +72,7 @@ Clearing floats
 ===============
 
 After a floated image, you may want subsequent content to appear below the
-image rather than wrapping around it. Use the ``clear-both`` class to clear
+image rather than wrapping around it. Use the :rst:`clear-both` class to clear
 floats:
 
 ..  code-block:: rst
@@ -89,7 +89,7 @@ floats:
 
     This text appears below the image.
 
-The ``..  rst-class:: clear-both`` directive applies the CSS ``clear: both``
+The :rst:`..  rst-class:: clear-both` directive applies the CSS `clear: both`
 property to the next element, forcing it below any floated content.
 
 ..  _image-float-responsive:
@@ -144,7 +144,7 @@ Example 9: figure aligned right
     :align: right
     :width: 150px
 
-    A figure aligned right via ``:align:``
+    A figure aligned right via :rst:`:align:`
 
 Typesetting is the composition of text by means of arranging physical types
 or the digital equivalents. Stored letters and other symbols are retrieved
@@ -201,11 +201,11 @@ Typesetting requires one or more fonts.
 Best practices for floating
 ===========================
 
-*   Always use ``..  rst-class:: clear-both`` after floated content to prevent
+*   Always use :rst:`..  rst-class:: clear-both` after floated content to prevent
     layout issues with subsequent sections
-*   Set an explicit ``:width:`` on floated images to control how much space
+*   Set an explicit :rst:`:width:` on floated images to control how much space
     text has to wrap around
 *   Floated figures are limited to 50% of the page width to ensure readability
-*   Prefer ``:align:`` on figures for cleaner RST syntax; use ``:class:`` when you
-    need to combine float with other classes like ``with-shadow``
+*   Prefer :rst:`:align:` on figures for cleaner RST syntax; use :rst:`:class:` when you
+    need to combine float with other classes like :rst:`with-shadow`
 *   Test on narrow viewports to verify the responsive behavior


### PR DESCRIPTION
Convert double-backtick inline code to single per this repo's own
"single unless double is needed" convention, skipping cases that
actually need double backticks and content inside code-block
examples. Also applies :rst:/:file: roles where the content is
reST syntax or a filename, instead of plain code.

Verified with the full Docker render pipeline.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf