### PR TITLE
[TASK] Replace :: literal blocks with code-block directives

### DIFF
--- a/Documentation/Reference/ReStructuredText/Content/Comments.rst
+++ b/Documentation/Reference/ReStructuredText/Content/Comments.rst
@@ -21,19 +21,25 @@ line, taking the indentation level into account.
 Examples
 --------
 
-Example::
+Example:
+
+..  code-block:: rst
 
     ..  So here we have a comment.
         It can spread over lines as
         long as you keep the indentation.
 
-Example::
+Example:
+
+..  code-block:: rst
 
     ..  This text will not be shown,
         but, for instance, in HTML might be
         rendered as an HTML comment, if the html writer is set up for that.
 
-Example::
+Example:
+
+..  code-block:: rst
 
     ..  here we start an unordered list:
 

--- a/Documentation/Reference/ReStructuredText/Lists/DefinitionLists.rst
+++ b/Documentation/Reference/ReStructuredText/Lists/DefinitionLists.rst
@@ -22,7 +22,9 @@ Example 1: no extra styling
 
 An example with a standard styling would look like this:
 
-Source::
+Source:
+
+..  code-block:: rst
 
     parameterAbc
         Condition: required, Type: string, Default: ''
@@ -56,7 +58,9 @@ This markup works but isn't very readable due to the lack of styling.
 Example 2: nicely styled
 ------------------------
 
-Source::
+Source:
+
+..  code-block:: rst
 
     ..  rst-class:: dl-parameters
 
@@ -138,7 +142,9 @@ intercept the list. Instead, many lists are created. This isn't
 a problem, if you repeat the 'rst-class' line.
 
 
-Source::
+Source:
+
+..  code-block:: rst
 
     ..  _label-parameterAbc:
     ..  rst-class:: dl-parameters
@@ -189,7 +195,9 @@ parameterBcd
 
 Link example:
 
-Source::
+Source:
+
+..  code-block:: rst
 
     Here we link to :ref:`A link text for parameterAbc <label-parameterAbc>`.
 

--- a/Documentation/Reference/ReStructuredText/Menus/ContentMenu.rst
+++ b/Documentation/Reference/ReStructuredText/Menus/ContentMenu.rst
@@ -21,7 +21,9 @@ Showing only a local content menu of all headlines, excluding the page header:
 ..  contents::
     :local:
 
-You can also limit the levels and or give the contents menu a title::
+You can also limit the levels and or give the contents menu a title:
+
+..  code-block:: rst
 
     ..  contents:: Table of Contents
         :local:


### PR DESCRIPTION
Bare "::" literal-block triggers render as plain unstyled text.
Replace all 8 occurrences with proper ".. code-block:: rst"
directives (all are RST source examples) to get syntax
highlighting, consistent with how code examples are shown
elsewhere in this repo.

Verified with the full Docker render pipeline and a render diff:
content is preserved, now with reST syntax highlighting applied.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf