### PR TITLE
[TASK] Document anchor persistence rule

### DIFF
--- a/Documentation/Advanced/Redirects.rst
+++ b/Documentation/Advanced/Redirects.rst
@@ -1,0 +1,85 @@
+:navigation-title: Redirects
+
+..  include:: /Includes.rst.txt
+..  index:: ! Redirects; Renaming pages; Deleting pages
+..  _redirects:
+
+====================================
+Redirecting renamed or deleted pages
+====================================
+
+Each `.rst` file published to docs.typo3.org is a page with its own URL.
+Unlike an anchor within a page (see :ref:`link anchors <link-anchor>`),
+there is no in-repo mechanism to keep an old file's URL working after it is
+renamed or deleted.
+
+This page describes a rule for the **official TYPO3 documentation
+repositories** (maintained under the `TYPO3-Documentation
+<https://github.com/TYPO3-Documentation>`__ organization — this manual,
+the Core API reference, and similar), not for third-party extension
+documentation — the process goes through a repository maintained by TYPO3
+GmbH, and does not scale to a pull request per extension for every rename.
+
+Within those official repositories, whenever a change renames or deletes a
+page — an actual change to the file's path, not just moving an anchor to a
+different heading within another page — a redirect for the old URL
+**must** be added, per the process below. Reviewers should ask for this on
+any PR that renames or deletes a page and does not already include it.
+This is not a courtesy: we have had real, concrete complaints from users
+who followed an old bookmarked or search-indexed link and landed on a hard
+404 with no explanation.
+
+..  _redirects-adding:
+
+Adding a redirect
+=================
+
+Redirects are configured in a **separate repository**,
+`TYPO3GmbH/site-intercept <https://github.com/TYPO3GmbH/site-intercept>`__,
+in the file :file:`config/nginx/redirects.conf`. Anyone can open a pull
+request there against the `develop` branch — you do not need to be a
+maintainer of this or any other documentation repository to do so.
+
+Add an nginx `location` rule for the old path, using your own repository's
+package name in place of `<repo-package>` below (for this manual, that is
+`docs-how-to-document`):
+
+*   **Renamed or moved to a different existing page** — redirect straight
+    to the new path:
+
+    ..  code-block:: nginx
+
+        location ~ ^/m/typo3/<repo-package>/(main|14.3)/en-us/Old/Path/Index.html$ {
+            return 303 /m/typo3/<repo-package>/$1/en-us/New/Path/Index.html;
+        }
+
+*   **Deleted, with no replacement** — redirect to a page that still
+    explains what happened, rather than to an unrelated page. A common
+    pattern is a dedicated :file:`Documentation/404.rst` page, with one
+    section per removed concept, that the redirect can link an anchor
+    within — see the `TYPO3 Core API reference's 404.rst
+    <https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/blob/main/Documentation/404.rst>`__
+    for a real example: :rst:`:orphan:` at the top (it is only ever
+    reached via a redirect, not linked from the table of contents), then
+    one section per TYPO3 version, each removed concept as its own
+    heading with the anchor(s) that used to point to it, a
+    :rst:`..  deprecated::` or :rst:`..  versionchanged::` directive
+    linking the changelog entry, and a short note on what to do instead.
+    Most repos won't need this from the start — create it the first time
+    you need to redirect removed content somewhere:
+
+    ..  code-block:: nginx
+
+        location ~ ^/m/typo3/<repo-package>/(main|14.3)/en-us/Old/Path/Index.html$ {
+            return 303 /m/typo3/<repo-package>/$1/en-us/404.html#old-concept-anchor;
+        }
+
+Scope the version group (`(main|14.3)`, `(main|14.3|13.4)`, ...) to the
+versions where the old path actually existed. Use `303` for a redirect to
+different content, `301` if it is genuinely permanent and the same content
+just moved.
+
+..  important::
+
+    :file:`redirects.conf` is shared production infrastructure for all of
+    docs.typo3.org — a syntax error there takes the whole site down.

--- a/Documentation/Reference/ReStructuredText/Links/Anchors.rst
+++ b/Documentation/Reference/ReStructuredText/Links/Anchors.rst
@@ -46,3 +46,33 @@ A recommended recipe could be:
 
 We are currently trying to let `Fractor support <https://github.com/andreaswolf/fractor/issues/206>`
 this and other transformations.
+
+..  _anchor-persistence:
+
+Keeping anchors working
+=======================
+
+An anchor is a promise: once a page containing it has reached `main`, the
+anchor **must** keep working, even after the heading it was on is gone.
+Never just delete an anchor. What to do instead depends on why the content
+went away:
+
+*   **Restructured, but the concept still exists somewhere** — a subchapter
+    or example merged into, or moved under, a different heading: move the
+    anchor to the heading that now covers that content, even if it is now
+    less specific (for example the parent chapter).
+
+*   **The whole concept was removed** — a breaking change, or it is no
+    longer the recommended approach: move the anchor into a
+    :file:`Documentation/404.rst` page instead (create it if it does not
+    exist yet), and add a short entry explaining what happened. See
+    :ref:`redirects` for the full pattern, including a real example.
+
+This applies everywhere, not just to official TYPO3 documentation
+repositories — anyone linking to your docs, from a bookmark, a search
+result, or another page, is relying on the anchor still being there.
+
+Also watch for malformed anchor lines (the wrong number of leading dots, a
+missing trailing colon) — they silently fail to work as a permalink, and
+can render as broken, stray text on the page instead of an invisible link
+target.


### PR DESCRIPTION
**Depends on #536** — this PR is based on `docs/renaming-deleting-pages` and its `:ref:`redirects`` link only resolves once that page exists. Please merge #536 first (or into it), then rebase/retarget this PR onto `main`.

---

An anchor is a promise: once a page containing it has reached main,
the anchor must keep working, even after the heading it was on is
gone. Document what to do instead of deleting it (move to the
covering heading, or into Documentation/404.rst for removed
concepts), referencing the redirects guide for the full pattern.
Unlike the redirects process itself, this rule applies to anyone
writing TYPO3 documentation, not just official repositories.

Also notes that malformed anchor lines silently fail instead of
erroring, which is easy to miss.

Verified with the full Docker render pipeline.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf