### PR TITLE
[TASK] Document :php:/:php-short: usage and update infobox behavior

### DIFF
--- a/Documentation/Reference/ReStructuredText/Code/InlineCode.rst
+++ b/Documentation/Reference/ReStructuredText/Code/InlineCode.rst
@@ -3,9 +3,9 @@
 ..  include:: /Includes.rst.txt
 ..  _inline-code:
 
-====================================
-Inline code with or without overlays
-====================================
+=====================================
+Inline code with or without infoboxes
+=====================================
 
 ..  hint::
 
@@ -13,8 +13,9 @@ Inline code with or without overlays
     unreadable. If this is the case, consider using
     `Code blocks with syntax highlighting <https://docs.typo3.org/permalink/h2document:writing-rest-codeblocks-with-syntax-highlighting>`_.
 
-Any text inside single or double backticks is printed as inline code. Double
-backticks allow unescaped backticks to be used in the code:
+Any text inside single or double backticks is printed as inline code. Use
+single backticks by default; double backticks are only needed when the
+code itself contains an unescaped backtick:
 
 ..  tabs::
 
@@ -26,12 +27,10 @@ backticks allow unescaped backticks to be used in the code:
 
         ..  literalinclude:: _snippets/_inline-code.rst.txt
 
-By convention single backticks are used unless double are needed.
-
 ..  _inline-code-language:
 
-Code roles with language information and overlay
-================================================
+Code roles with language information and an infobox
+===================================================
 
 You can also use `text roles <https://docs.typo3.org/permalink/h2document:text-roles>`_ with one of the predefined languages to display more
 information to the user. For the most common languages, automatic
@@ -47,11 +46,64 @@ detection provides more context for the user.
 
         ..  literalinclude:: _snippets/_inline-code-languages.rst.txt
 
-PHP classes from the TYPO3 Core are automatically linked to https://api.typo3.org
-and display the PHP doc comment (if any) in the overlay.
+All named inline code roles show an icon right after the code that opens
+an infobox with details about it — the language, and for a resolvable
+PHP class from the TYPO3 Core, its doc comment (if any) and a link to
+https://api.typo3.org. The code text itself stays plain, selectable text,
+so it can be copied directly instead of accidentally opening the infobox.
 
-All named inline code roles show an overlay where the code can be conveniently
-copied and information on the language of the code.
+..  _inline-code-php:
+
+`:php:` and `:php-short:`
+=========================
+
+Use :rst:`:php:` and :rst:`:php-short:` when the text is a real,
+resolvable PHP identifier — a class, method, constant, or function — so
+the infobox can tell the reader something genuinely useful about it. If
+the tooling has nothing to resolve, the "PHP" tag and the infobox button
+are just noise, and worse, they promise a lookup that goes nowhere. In
+those cases a plain literal reads more honestly:
+
+*   A TCA key, `CType`, array key, or YAML config key looks like it lives
+    in PHP because it is often written inside a PHP array, but the key
+    itself is just a string, not an identifier the PHP domain can
+    resolve. Write it as a plain literal instead:
+
+    ..  code-block:: rst
+
+        The `enablecolumns` key ...
+
+*   When referencing a class, interface, or similar type on its own, pass
+    the fully-qualified name (leading backslash, full namespace) to
+    :rst:`:php-short:` rather than :rst:`:php:`. It still resolves the
+    infobox content from the FQCN, but displays only the short name,
+    which reads much better inline than the full namespace:
+
+    ..  code-block:: rst
+
+        :php-short:`\TYPO3\CMS\Core\Security\ContentSecurityPolicy`
+
+    As of this writing, :rst:`:php-short:` only resolves a bare type this
+    way, not a type combined with a method, such as `Scope::backend()`.
+    For those, use :rst:`:php:` with the full FQCN instead — it reads
+    longer, but it is the one that actually resolves:
+
+    ..  code-block:: rst
+
+        :php:`\TYPO3\CMS\Core\Security\ContentSecurityPolicy\Scope::backend()`
+
+*   When you are talking about a concept rather than naming a specific,
+    resolvable class — for example "a PreviewRenderer" used generically,
+    not `\Vendor\Ext\PreviewRenderer` — a plain literal fits better, since
+    there is no single class the infobox could point to.
+
+*   Headlines are the one place to leave roles out entirely, including
+    :rst:`:php:`/:rst:`:php-short:` — use plain backticks there even for
+    something that would get a role in body text. A role's code styling
+    and infobox button do not read well in a heading, and they disappear
+    wherever the heading's text gets reused as plain text elsewhere — for
+    example a bare :rst:`:ref:` to it falls back to unstyled text instead
+    of keeping the code formatting.
 
 ..  seealso::
 


### PR DESCRIPTION
Add guidance on when to use :php:/:php-short: (real, resolvable PHP
identifiers only, not TCA/config keys or generic concepts), the
FQCN requirement, and why they should never appear in a headline.
Notes the current :php-short: limitation: it only resolves a bare
type, not a type combined with a method.

Also corrects the outdated description of how the info box works:
it now opens via an icon after the code instead of the code itself
being clickable, so the code text stays selectable for copying.
Renamed "overlay" to "infobox" throughout to match current
terminology and existing usage elsewhere in this repo, and leads
with the single-backtick preference in the intro instead of
mentioning it only after the double-backtick example.

Verified with the full Docker render pipeline.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf