### PR TITLE
[TASK] Warn that --output is resolved inside the container

### DIFF
--- a/Documentation/Howto/Migration/MarkdownToReST.rst
+++ b/Documentation/Howto/Migration/MarkdownToReST.rst
@@ -55,6 +55,13 @@ We will use :file:`Documentation-Migrated` as the output directory.
             New-Item -ItemType Directory -Force -Path ".\Documentation-Migrated"
             docker run --rm --pull always -v ${PWD}:/project -it ghcr.io/typo3-documentation/render-guides:latest --theme=rst --output-format=rst --output Documentation-Migrated
 
+..  note::
+    :bash:`--output` is resolved inside the container, so the path has to stay
+    below the mounted volume (:bash:`-v $(pwd):/project`). A path outside it is
+    written to the container's own file system and disappears with the
+    container, while the command still reports the files as placed. The
+    relative :file:`Documentation-Migrated` above satisfies this.
+
 Now we can copy the :file:`guides.xml` from the original directory documentation directory to the new directory. And remove the
 option `input-format="md"`. This will tell the rendering toolchain to use the ReST files instead of the Markdown files.
 

--- a/Documentation/_Includes/_LocalRendering.rst.txt
+++ b/Documentation/_Includes/_LocalRendering.rst.txt
@@ -5,13 +5,3 @@
 
 Open the file saved to :file:`Documentation-GENERATED-temp/Index.html` in a
 browser of your choice.
-
-..  note::
-    The :bash:`--output` option is resolved **inside** the container. If it
-    points to a path that is not below the mounted volume
-    (:bash:`-v $(pwd):/project`), the rendered files are written to the
-    container's own file system and discarded when the container is removed —
-    while the command still reports that the files were placed successfully.
-    Either omit :bash:`--output` (default:
-    :file:`Documentation-GENERATED-temp`) or use a path below
-    :file:`/project`.

--- a/Documentation/_Includes/_LocalRendering.rst.txt
+++ b/Documentation/_Includes/_LocalRendering.rst.txt
@@ -5,3 +5,13 @@
 
 Open the file saved to :file:`Documentation-GENERATED-temp/Index.html` in a
 browser of your choice.
+
+..  note::
+    The :bash:`--output` option is resolved **inside** the container. If it
+    points to a path that is not below the mounted volume
+    (:bash:`-v $(pwd):/project`), the rendered files are written to the
+    container's own file system and discarded when the container is removed —
+    while the command still reports that the files were placed successfully.
+    Either omit :bash:`--output` (default:
+    :file:`Documentation-GENERATED-temp`) or use a path below
+    :file:`/project`.


### PR DESCRIPTION
The `--output` option of the render container is resolved inside the container: pointing it at a host path outside the mounted volume writes the files into the container file system, which `--rm` then discards — while the command still reports success. This adds a note to the shared local-rendering include so every page showing the command carries the warning.