### PR TITLE
[TASK] Document php:method signature parser limitations

### DIFF
--- a/Documentation/Reference/ReStructuredText/Code/Phpdomain.rst
+++ b/Documentation/Reference/ReStructuredText/Code/Phpdomain.rst
@@ -328,3 +328,27 @@ We are currently working on the automatic generation of PHP domain syntax
 from PHP classes within the
 `TYPO3 Screenshots <https://github.com/TYPO3-Documentation/t3docs-screenshots/pull/234>`__
 tool.
+
+..  _rest-phpdomain-signature-limitations:
+
+Limitations of the method signature parser
+==========================================
+
+The signature parser does not understand all modern PHP type syntax. Nullable
+types (:php:`?string`) and union types (:php:`string|null`,
+:php:`string|array`) in the signature lead to build warnings or wrong output.
+
+Declare such types in the field list instead:
+
+..  code-block:: rst
+
+    ..  php:method:: retrieve(string $identifier)
+
+        Retrieve a value.
+
+        :param string $identifier: The identifier.
+        :returns: The stored value or `null` if not found.
+        :returntype: string|null
+
+For a nullable parameter, give it a default of `null` in the signature and
+document the type as `string|null` in the :rst:`:param:` field.

--- a/Documentation/Reference/ReStructuredText/Code/Phpdomain.rst
+++ b/Documentation/Reference/ReStructuredText/Code/Phpdomain.rst
@@ -336,11 +336,17 @@ Limitations of the method signature parser
 
 The restriction applies to the **return type** after the colon: it has to be a
 single word. A nullable type (:php:`?string`), a union type
-(:php:`string|null`), and a fully qualified class name (:php:`\Vendor\Thing`)
-are all rejected, and the whole signature is then reported as invalid.
+(:php:`string|null`), an intersection type (:php:`Countable&Traversable`) and a
+fully qualified class name (:php:`\Vendor\Thing`) are all rejected.
 
 Parameter types are not restricted — :php:`?string $identifier` and
-:php:`string|null $identifier` are accepted.
+:php:`string|null $identifier` are accepted, as are :php:`static`,
+:php:`array` and a missing return type.
+
+A rejected signature does not only produce a build warning. The whole text is
+then taken as the method name, so the parameters disappear, an empty
+:rst:`()` is rendered after it, and the anchor is built from the entire
+signature — which means cross references to that method cannot resolve.
 
 So leave a return type of that kind out of the signature and declare it in the
 field list:

--- a/Documentation/Reference/ReStructuredText/Code/Phpdomain.rst
+++ b/Documentation/Reference/ReStructuredText/Code/Phpdomain.rst
@@ -334,21 +334,23 @@ tool.
 Limitations of the method signature parser
 ==========================================
 
-The signature parser does not understand all modern PHP type syntax. Nullable
-types (:php:`?string`) and union types (:php:`string|null`,
-:php:`string|array`) in the signature lead to build warnings or wrong output.
+The restriction applies to the **return type** after the colon: it has to be a
+single word. A nullable type (:php:`?string`), a union type
+(:php:`string|null`), and a fully qualified class name (:php:`\Vendor\Thing`)
+are all rejected, and the whole signature is then reported as invalid.
 
-Declare such types in the field list instead:
+Parameter types are not restricted — :php:`?string $identifier` and
+:php:`string|null $identifier` are accepted.
+
+So leave a return type of that kind out of the signature and declare it in the
+field list:
 
 ..  code-block:: rst
 
-    ..  php:method:: retrieve(string $identifier)
+    ..  php:method:: retrieve(?string $identifier)
 
         Retrieve a value.
 
         :param string $identifier: The identifier.
         :returns: The stored value or `null` if not found.
         :returntype: string|null
-
-For a nullable parameter, give it a default of `null` in the signature and
-document the type as `string|null` in the :rst:`:param:` field.


### PR DESCRIPTION
The php:method signature parser rejects modern PHP type syntax (`?string`, union types) with build warnings or wrong output, and the page currently does not mention it. This documents the limitation and the `:returntype:`/`:param:` workaround, plus a short note that array-based configuration (TCA, FlexForm, YAML) belongs in confval rather than the PHP domain.