### PR TITLE
[TASK] Comments: document that todo notes are dropped on render

### DIFF
--- a/Documentation/Reference/ReStructuredText/Content/Comments.rst
+++ b/Documentation/Reference/ReStructuredText/Content/Comments.rst
@@ -52,3 +52,12 @@ Example:
 
     *   three
 
+..  _writing-rest-comments-todo:
+
+Open tasks (todo)
+-----------------
+
+The TYPO3 documentation renderer silently drops a :rst:`..  todo::`
+directive — its content never reaches the rendered page. Do not rely on it
+as a visible marker: resolve open tasks before merging, or write them as
+plain comments (dot-dot-blank) so they stay clearly author-only.

--- a/Documentation/Reference/ReStructuredText/Content/Comments.rst
+++ b/Documentation/Reference/ReStructuredText/Content/Comments.rst
@@ -57,7 +57,12 @@ Example:
 Open tasks (todo)
 -----------------
 
-The TYPO3 documentation renderer silently drops a :rst:`..  todo::`
-directive — its content never reaches the rendered page. Do not rely on it
-as a visible marker: resolve open tasks before merging, or write them as
-plain comments (dot-dot-blank) so they stay clearly author-only.
+Use :rst:`..  todo::` for notes addressed to other authors. Its content never
+reaches the rendered page, which is intended: a todo note is internal. It is
+the better choice over a plain comment, because ``todo::`` is a distinct string
+that can be searched for, while :rst:`..` alone also begins every directive and
+every anchor.
+
+The flip side is that nothing reminds you of it while reading the rendered
+page. Search for ``todo::`` before merging instead of expecting to notice an
+open task in a preview.


### PR DESCRIPTION
Adds a short section that todo notes must not remain in published documentation — resolve them before merging or demote them to author-only comments.