### PR TITLE
[TASK] Warn against symlinks inside the Documentation folder

### DIFF
--- a/Documentation/Reference/FileStructure.rst
+++ b/Documentation/Reference/FileStructure.rst
@@ -40,6 +40,12 @@ Further conventions are:
 *   Code examples to be included should start with an underscore, for example
     :file:`_Services.yaml`.
 
+..  note::
+    Do not place symbolic links inside the :path:`Documentation` folder. The
+    rendering walks the directory tree literally; a symlink (for example an
+    :file:`AGENTS.md` or :file:`CLAUDE.md` link created by AI tooling) breaks
+    the file walk and thereby the rendering.
+
 ..  _full-documentation:
 
 Full documentation in reST


### PR DESCRIPTION
A symbolic link inside Documentation/ (for example an AGENTS.md or CLAUDE.md link created by AI tooling) breaks the renderer's file walk. Adds a note to the rendering prerequisites.